### PR TITLE
TDQ-12169: Fix for file leak issues in SemanticQualityAnalyzer

### DIFF
--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/recognizer/CategoryRecognizer.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/recognizer/CategoryRecognizer.java
@@ -14,6 +14,9 @@ package org.talend.dataquality.semantic.recognizer;
 
 import java.util.Collection;
 
+import org.talend.dataquality.semantic.classifier.custom.UserDefinedClassifier;
+import org.talend.dataquality.semantic.classifier.impl.DataDictFieldClassifier;
+
 /**
  * created by talend on 2015-07-28 Detailled comment.
  * 
@@ -25,6 +28,10 @@ public interface CategoryRecognizer {
     void reset();
 
     String[] process(String data);
+
+    DataDictFieldClassifier getDataDictFieldClassifier();
+
+    UserDefinedClassifier getUserDefineClassifier();
 
     Collection<CategoryFrequency> getResult();
 

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/recognizer/DefaultCategoryRecognizer.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/recognizer/DefaultCategoryRecognizer.java
@@ -54,6 +54,16 @@ class DefaultCategoryRecognizer implements CategoryRecognizer {
         userDefineClassifier = UDCategorySerDeser.getRegexClassifier();
     }
 
+    @Override
+    public DataDictFieldClassifier getDataDictFieldClassifier() {
+        return dataDictFieldClassifier;
+    }
+
+    @Override
+    public UserDefinedClassifier getUserDefineClassifier() {
+        return userDefineClassifier;
+    }
+
     /**
      * @param data the input value
      * @return the set of its semantic categories


### PR DESCRIPTION
* Prevent creation of LuceneIndex (since they can't be properly closed).