### PR TITLE
TDQ-13389 Addition of "count" setter in CardinalityHLLStatistics class

### DIFF
--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
@@ -51,7 +51,9 @@ public class CardinalityHLLStatistics {
 
     public void setHyperLogLog(HyperLogLog hyperLogLog2) {
         this.hyperLogLog = hyperLogLog2;
-
     }
-
+    
+    public void setCount(long count) {
+        this.count = count;
+    }
 }


### PR DESCRIPTION
I need to add the setCount method in order to merge together two instances of CardinalityHLLStatistics