### PR TITLE
TDQ-13389: add the class AbstractCardinalityStatistics

### DIFF
--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/AbstractCardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/AbstractCardinalityStatistics.java
@@ -1,0 +1,27 @@
+package org.talend.dataquality.statistics.cardinality;
+
+/**
+ * Created by afournier on 31/03/17.
+ */
+public abstract class AbstractCardinalityStatistics {
+
+    protected long count = 0;
+
+    public long getCount() {
+        return this.count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    public void incrementCount() {
+        this.count++;
+    }
+
+    public abstract long getDistinctCount();
+
+    public long getDuplicateCount() {
+        return this.count - getDistinctCount();
+    }
+}

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLAnalyzer.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLAnalyzer.java
@@ -46,7 +46,7 @@ public class CardinalityHLLAnalyzer implements Analyzer<CardinalityHLLStatistics
 
     /**
      * Set the hyper log log parameter
-     * 
+     *
      * @param rsd
      */
     public void setRelativeStandardDeviation(int rsd) {

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
@@ -15,14 +15,12 @@ package org.talend.dataquality.statistics.cardinality;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 
 /**
- * Cardianlity statistics bean of hypper log log .
+ * Cardinality statistics bean of hyper log log .
  * 
  * @author zhao
  *
  */
-public class CardinalityHLLStatistics {
-
-    private long count = 0L;
+public class CardinalityHLLStatistics extends AbstractCardinalityStatistics {
 
     private HyperLogLog hyperLogLog = null;
 
@@ -33,27 +31,12 @@ public class CardinalityHLLStatistics {
         return hyperLogLog;
     }
 
-    public long getDuplicateCount() {
-        return count - getDistinctCount();
-    }
-
-    public long getCount() {
-        return count;
-    }
-
     public long getDistinctCount() {
         return hyperLogLog.cardinality();
-    }
-
-    public void incrementCount() {
-        count += 1;
     }
 
     public void setHyperLogLog(HyperLogLog hyperLogLog2) {
         this.hyperLogLog = hyperLogLog2;
     }
 
-    public void setCount(long count) {
-        this.count = count;
-    }
 }

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
@@ -16,31 +16,21 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Compute cardinalities in memory, use {@link #CardinalityHLLAnalyzer()} instead if large data set are computed.
+ * Compute cardinalities in memory, use {@link CardinalityHLLAnalyzer} instead if large data set are computed.
  * 
  * @author zhao
  *
  */
-public class CardinalityStatistics {
+public class CardinalityStatistics extends AbstractCardinalityStatistics {
 
     private final Set<String> distinctData = new HashSet<>();
-
-    private long count = 0;
 
     public void add(String colStr) {
         distinctData.add(colStr);
     }
 
-    public void incrementCount() {
-        count++;
-    }
-
     public long getDistinctCount() {
         return distinctData.size();
-    }
-
-    public long getDuplicateCount() {
-        return count - getDistinctCount();
     }
 
 }


### PR DESCRIPTION
I need to add an abstract class for CardinalityStatistics and CardinalityHLLStatistics so they have the same type (that is, AbstractCardinalityStatistics). 
It will be useful for me to create the Coder and serialize it in Beam.