### PR TITLE
Tdq 13389 cardinality statistics refactory

### DIFF
--- a/dataquality-statistics/.classpath
+++ b/dataquality-statistics/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry including="**/*.java" kind="src" path="src/main/java"/>
+<classpathentry including="**/*.java" kind="src" path="src/main/java"/>
 	<classpathentry excluding="**/*.java" kind="src" path="src/main/resources"/>
 	<classpathentry including="**/*.java" kind="src" output="target/classes" path="src/test/java"/>
 	<classpathentry excluding="**/*.java" kind="src" output="target/classes" path="src/test/resources"/>

--- a/dataquality-statistics/.classpath
+++ b/dataquality-statistics/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-<classpathentry including="**/*.java" kind="src" path="src/main/java"/>
+    <classpathentry including="**/*.java" kind="src" path="src/main/java"/>
 	<classpathentry excluding="**/*.java" kind="src" path="src/main/resources"/>
 	<classpathentry including="**/*.java" kind="src" output="target/classes" path="src/test/java"/>
 	<classpathentry excluding="**/*.java" kind="src" output="target/classes" path="src/test/resources"/>

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/AbstractCardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/AbstractCardinalityStatistics.java
@@ -1,9 +1,11 @@
 package org.talend.dataquality.statistics.cardinality;
 
+import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
+
 /**
  * Created by afournier on 31/03/17.
  */
-public abstract class AbstractCardinalityStatistics {
+public abstract class AbstractCardinalityStatistics<T extends AbstractCardinalityStatistics> {
 
     protected long count = 0;
 
@@ -17,5 +19,7 @@ public abstract class AbstractCardinalityStatistics {
         return this.count - getDistinctCount();
     }
 
-    public abstract boolean merge(AbstractCardinalityStatistics other);
+    public abstract void merge(T other) throws CardinalityMergeException;
+
+    public abstract void add(String colStr);
 }

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/AbstractCardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/AbstractCardinalityStatistics.java
@@ -1,0 +1,27 @@
+package org.talend.dataquality.statistics.cardinality;
+
+/**
+ * Created by afournier on 31/03/17.
+ */
+public abstract class AbstractCardinalityStatistics {
+
+    protected long count = 0;
+
+    public long getCount() {
+        return this.count;
+    }
+
+    public void setCount(long count) {
+        this.count = count;
+    }
+
+    public void incrementCount() {
+        this.count++;
+    }
+
+    public abstract long getDistinctCount();
+
+    public long getDuplicateCount() {
+        return this.count - getDistinctCount();
+    }
+}

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/AbstractCardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/AbstractCardinalityStatistics.java
@@ -7,14 +7,6 @@ public abstract class AbstractCardinalityStatistics {
 
     protected long count = 0;
 
-    public long getCount() {
-        return this.count;
-    }
-
-    public void setCount(long count) {
-        this.count = count;
-    }
-
     public void incrementCount() {
         this.count++;
     }
@@ -24,4 +16,6 @@ public abstract class AbstractCardinalityStatistics {
     public long getDuplicateCount() {
         return this.count - getDistinctCount();
     }
+
+    public abstract boolean merge(AbstractCardinalityStatistics other);
 }

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityAnalyzer.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityAnalyzer.java
@@ -20,10 +20,9 @@ import org.talend.dataquality.common.inference.ResizableList;
 
 /**
  * Be caution that this implementation will lead to serious memory issues when data becoming large. Use {
- * {@link #CardianlityHLLAnalyzer()} instead by loose the precision.
- * 
- * @author zhao
+ * {@link CardinalityHLLAnalyzer} instead by loose the precision.
  *
+ * @author zhao
  */
 public class CardinalityAnalyzer implements Analyzer<CardinalityStatistics> {
 

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLAnalyzer.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLAnalyzer.java
@@ -63,7 +63,7 @@ public class CardinalityHLLAnalyzer implements Analyzer<CardinalityHLLStatistics
             if (cardStats.getHyperLogLog() == null) {
                 cardStats.setHyperLogLog(new HyperLogLog(rsd));
             }
-            cardStats.getHyperLogLog().offer(record[i]);
+            cardStats.add(record[i]);
             cardStats.incrementCount();
         }
         return true;

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLAnalyzer.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLAnalyzer.java
@@ -22,22 +22,21 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 
 /**
  * Using hyperloglog estimating cardinalities (distinct count)<br/>
- * Parmater <code>rsd</code> can be set in order to have a better balance between precision and space. by {
+ * Parameter <code>rsd</code> can be set in order to have a better balance between precision and space. by {
  * {@link #setRelativeStandardDeviation(int)}<br/>
  * See more description about this parameter at <a href=
  * "https://github.com/addthis/stream-lib/blob/master/src/main/java/com/clearspring/analytics/stream/cardinality/HyperLogLog.java#L93"
- * >Hypper log log parameter</a>
- * 
- * @author zhao
+ * >Hyper log log parameter</a>
  *
+ * @author zhao
  */
 public class CardinalityHLLAnalyzer implements Analyzer<CardinalityHLLStatistics> {
 
     private static final long serialVersionUID = -5813206492367921798L;
 
-    private ResizableList<CardinalityHLLStatistics> cardinalityStatistics = null;
-
     int rsd = 20; // relative standard deviation
+
+    private ResizableList<CardinalityHLLStatistics> cardinalityStatistics = null;
 
     @Override
     public void init() {

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLAnalyzer.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLAnalyzer.java
@@ -46,7 +46,7 @@ public class CardinalityHLLAnalyzer implements Analyzer<CardinalityHLLStatistics
 
     /**
      * Set the hyper log log parameter
-     * 
+     *
      * @param rsd
      */
     public void setRelativeStandardDeviation(int rsd) {

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
@@ -12,6 +12,7 @@
 // ============================================================================
 package org.talend.dataquality.statistics.cardinality;
 
+import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 
 /**
@@ -19,7 +20,7 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
  *
  * @author zhao
  */
-public class CardinalityHLLStatistics extends AbstractCardinalityStatistics {
+public class CardinalityHLLStatistics extends AbstractCardinalityStatistics<CardinalityHLLStatistics> {
 
     private HyperLogLog hyperLogLog = null;
 
@@ -38,6 +39,10 @@ public class CardinalityHLLStatistics extends AbstractCardinalityStatistics {
         return hyperLogLog.cardinality();
     }
 
+    public void add(String colStr) {
+        this.hyperLogLog.offer(colStr);
+    }
+
     /**
      * <b>This method merges two instances of CardinalityHLLStatistics. </b>
      * <p>
@@ -51,17 +56,8 @@ public class CardinalityHLLStatistics extends AbstractCardinalityStatistics {
      * @param other An other instance of CardinalityHLLStatistics
      * @return boolean that indicates if the merge was possible
      */
-    public boolean merge(AbstractCardinalityStatistics other) {
-        if (!(other instanceof CardinalityHLLStatistics))
-            return false;
-
-        CardinalityHLLStatistics cardStat = (CardinalityHLLStatistics) other;
+    public void merge(CardinalityHLLStatistics other) throws CardinalityMergeException {
+        this.hyperLogLog.addAll(other.hyperLogLog);
         super.count += other.count;
-        try {
-            this.hyperLogLog.addAll(cardStat.hyperLogLog);
-            return true;
-        } catch (Exception e) {
-            return false;
-        }
     }
 }

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
@@ -31,11 +31,12 @@ public class CardinalityHLLStatistics extends AbstractCardinalityStatistics {
         return hyperLogLog;
     }
 
+    public void setHyperLogLog(HyperLogLog hyperLogLog2) {
+        this.hyperLogLog = hyperLogLog2;
+    }
+
     public long getDistinctCount() {
         return hyperLogLog.cardinality();
     }
 
-    public void setHyperLogLog(HyperLogLog hyperLogLog2) {
-        this.hyperLogLog = hyperLogLog2;
-    }
 }

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
@@ -16,9 +16,8 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 
 /**
  * Cardinality statistics bean of hyper log log .
- * 
- * @author zhao
  *
+ * @author zhao
  */
 public class CardinalityHLLStatistics extends AbstractCardinalityStatistics {
 
@@ -39,4 +38,30 @@ public class CardinalityHLLStatistics extends AbstractCardinalityStatistics {
         return hyperLogLog.cardinality();
     }
 
+    /**
+     * <b>This method merges two instances of CardinalityHLLStatistics. </b>
+     * <p>
+     * If the instance to merge is not of the type CardinalityHLLStatistics (but CardinalityStatistics),
+     * the method will return false to indicate that the merge was not possible.
+     * Also, if the other instance is a instance of CardinalityHLLStatistics but its {@link HyperLogLog} instance
+     * cannot be merged with the current HyperLogLog instance, this method will catch the exception triggered by
+     * the {@link HyperLogLog#addAll(HyperLogLog)} method and return false.
+     * </p>
+     *
+     * @param other An other instance of CardinalityHLLStatistics
+     * @return boolean that indicates if the merge was possible
+     */
+    public boolean merge(AbstractCardinalityStatistics other) {
+        if (!(other instanceof CardinalityHLLStatistics))
+            return false;
+
+        CardinalityHLLStatistics cardStat = (CardinalityHLLStatistics) other;
+        super.count += other.count;
+        try {
+            this.hyperLogLog.addAll(cardStat.hyperLogLog);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
@@ -15,14 +15,12 @@ package org.talend.dataquality.statistics.cardinality;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 
 /**
- * Cardianlity statistics bean of hypper log log .
+ * Cardinality statistics bean of hyper log log .
  * 
  * @author zhao
  *
  */
-public class CardinalityHLLStatistics {
-
-    private long count = 0L;
+public class CardinalityHLLStatistics extends AbstractCardinalityStatistics {
 
     private HyperLogLog hyperLogLog = null;
 
@@ -33,27 +31,11 @@ public class CardinalityHLLStatistics {
         return hyperLogLog;
     }
 
-    public long getDuplicateCount() {
-        return count - getDistinctCount();
-    }
-
-    public long getCount() {
-        return count;
-    }
-
     public long getDistinctCount() {
         return hyperLogLog.cardinality();
     }
 
-    public void incrementCount() {
-        count += 1;
-    }
-
     public void setHyperLogLog(HyperLogLog hyperLogLog2) {
         this.hyperLogLog = hyperLogLog2;
-    }
-
-    public void setCount(long count) {
-        this.count = count;
     }
 }

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
@@ -12,8 +12,6 @@
 // ============================================================================
 package org.talend.dataquality.statistics.cardinality;
 
-import com.clearspring.analytics.stream.cardinality.HyperLogLog;
-
 import java.util.HashSet;
 import java.util.Set;
 

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
@@ -20,7 +20,7 @@ import java.util.Set;
  *
  * @author zhao
  */
-public class CardinalityStatistics extends AbstractCardinalityStatistics {
+public class CardinalityStatistics extends AbstractCardinalityStatistics<CardinalityStatistics> {
 
     private final Set<String> distinctData = new HashSet<>();
 
@@ -42,15 +42,9 @@ public class CardinalityStatistics extends AbstractCardinalityStatistics {
      * @param other An other instance of CardinalityStatistics
      * @return boolean that indicates if the merge was possible.
      */
-    public boolean merge(AbstractCardinalityStatistics other) {
-        if (!(other instanceof CardinalityStatistics))
-            return false;
-
-        CardinalityStatistics cardStat = (CardinalityStatistics) other;
+    public void merge(CardinalityStatistics other) {
         super.count += other.count;
-        distinctData.addAll(cardStat.distinctData);
-
-        return true;
+        distinctData.addAll(other.distinctData);
     }
 
 }

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
@@ -12,14 +12,15 @@
 // ============================================================================
 package org.talend.dataquality.statistics.cardinality;
 
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+
 import java.util.HashSet;
 import java.util.Set;
 
 /**
  * Compute cardinalities in memory, use {@link CardinalityHLLAnalyzer} instead if large data set are computed.
- * 
- * @author zhao
  *
+ * @author zhao
  */
 public class CardinalityStatistics extends AbstractCardinalityStatistics {
 
@@ -31,6 +32,27 @@ public class CardinalityStatistics extends AbstractCardinalityStatistics {
 
     public long getDistinctCount() {
         return distinctData.size();
+    }
+
+    /**
+     * <b>This method merges two instances of CardinalityStatistics. </b>
+     * <p>
+     * If the instance to merge is not of the type CardinalityStatistics (but CardinalityHLLStatistics),
+     * the method will return false to indicate that the merge was not possible.
+     * </p>
+     *
+     * @param other An other instance of CardinalityStatistics
+     * @return boolean that indicates if the merge was possible.
+     */
+    public boolean merge(AbstractCardinalityStatistics other) {
+        if (!(other instanceof CardinalityStatistics))
+            return false;
+
+        CardinalityStatistics cardStat = (CardinalityStatistics) other;
+        super.count += other.count;
+        distinctData.addAll(cardStat.distinctData);
+
+        return true;
     }
 
 }

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
@@ -16,31 +16,21 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * Compute cardinalities in memory, use {@link #CardinalityHLLAnalyzer()} instead if large data set are computed.
+ * Compute cardinalities in memory, use {@link CardinalityHLLAnalyzer} instead if large data set are computed.
  * 
  * @author zhao
  *
  */
-public class CardinalityStatistics {
+public class CardinalityStatistics extends AbstractCardinalityStatistics {
 
     private final Set<String> distinctData = new HashSet<>();
-
-    private long count = 0;
 
     public void add(String colStr) {
         distinctData.add(colStr);
     }
 
-    public void incrementCount() {
-        count++;
-    }
-
     public long getDistinctCount() {
         return distinctData.size();
-    }
-
-    public long getDuplicateCount() {
-        return count - getDistinctCount();
     }
 
 }

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatisticsTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatisticsTest.java
@@ -1,12 +1,11 @@
 package org.talend.dataquality.statistics.cardinality;
 
-import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 
 /**
  * Created by afournier on 31/03/17.

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatisticsTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatisticsTest.java
@@ -1,0 +1,55 @@
+package org.talend.dataquality.statistics.cardinality;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by afournier on 31/03/17.
+ */
+public class CardinalityHLLStatisticsTest {
+
+    private static CardinalityHLLStatistics cardHLLStats;
+
+    @Before
+    public void setUp() throws Exception {
+        cardHLLStats = new CardinalityHLLStatistics();
+        cardHLLStats.setHyperLogLog(new HyperLogLog(20));
+    }
+
+    @Test
+    public void testUnpossibleMerge() {
+        CardinalityStatistics cardStat = new CardinalityStatistics();
+        for (int i = 0; i < 1000; i++) {
+            cardHLLStats.incrementCount();
+            cardStat.incrementCount();
+            String str = RandomStringUtils.randomAscii(2);
+            cardHLLStats.getHyperLogLog().offer(str);
+            cardStat.add(str);
+        }
+
+        Assert.assertEquals(false, cardHLLStats.merge(cardStat));
+    }
+
+    @Test
+    public void testPossibleMerge() {
+        CardinalityHLLStatistics otherCardHLLStat = new CardinalityHLLStatistics();
+        otherCardHLLStat.setHyperLogLog(new HyperLogLog(20));
+        for (int i = 0; i < 1000; i++) {
+            cardHLLStats.incrementCount();
+            otherCardHLLStat.incrementCount();
+            String str = RandomStringUtils.randomAscii(2);
+            cardHLLStats.getHyperLogLog().offer(str);
+            otherCardHLLStat.getHyperLogLog().offer(str);
+        }
+
+        Assert.assertEquals(true, cardHLLStats.merge(otherCardHLLStat));
+        // The merge should not have changed the cardinality because every element was the same for both in the loop.
+        Assert.assertEquals(cardHLLStats.getDistinctCount(), otherCardHLLStat.getDistinctCount());
+    }
+
+}

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityStatisticsTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityStatisticsTest.java
@@ -1,5 +1,6 @@
 package org.talend.dataquality.statistics.cardinality;
 
+import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Before;
@@ -19,20 +20,10 @@ public class CardinalityStatisticsTest {
         cardStats = new CardinalityStatistics();
     }
 
-    @Test
-    public void testUnpossibleMerge() {
-        CardinalityHLLStatistics cardHLL = new CardinalityHLLStatistics();
-        cardHLL.setHyperLogLog(new HyperLogLog(20));
-
-        for (int i = 0; i < 1000; i++) {
-            cardStats.incrementCount();
-            cardHLL.incrementCount();
-            String str = RandomStringUtils.randomAscii(2);
-            cardStats.add(str);
-            cardHLL.getHyperLogLog().offer(str);
-        }
-
-        Assert.assertEquals(false, cardStats.merge(cardHLL));
+    @Test(expected = ClassCastException.class)
+    public void testDifferentTypeMerge() throws CardinalityMergeException {
+        AbstractCardinalityStatistics stat1 = new CardinalityHLLStatistics();
+        stat1.merge(cardStats);
     }
 
     @Test
@@ -45,9 +36,7 @@ public class CardinalityStatisticsTest {
             cardStats.add(str);
             otherCardStat.add(str);
         }
-
-        Assert.assertEquals(true, cardStats.merge(otherCardStat));
-        // The merge should not have changed the cardinality because every element was the same for both in the loop.
+        cardStats.merge(otherCardStat);
         Assert.assertEquals(cardStats.getDistinctCount(), otherCardStat.getDistinctCount());
     }
 }

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityStatisticsTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityStatisticsTest.java
@@ -1,0 +1,52 @@
+package org.talend.dataquality.statistics.cardinality;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import org.apache.commons.lang.RandomStringUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Created by afournier on 31/03/17.
+ */
+public class CardinalityStatisticsTest {
+
+    private static CardinalityStatistics cardStats;
+
+    @Before
+    public void setUp() throws Exception {
+        cardStats = new CardinalityStatistics();
+    }
+
+    @Test
+    public void testUnpossibleMerge() {
+        CardinalityHLLStatistics cardHLL = new CardinalityHLLStatistics();
+        cardHLL.setHyperLogLog(new HyperLogLog(20));
+
+        for (int i = 0; i < 1000; i++) {
+            cardStats.incrementCount();
+            cardHLL.incrementCount();
+            String str = RandomStringUtils.randomAscii(2);
+            cardStats.add(str);
+            cardHLL.getHyperLogLog().offer(str);
+        }
+
+        Assert.assertEquals(false, cardStats.merge(cardHLL));
+    }
+
+    @Test
+    public void testPossibleMerge() {
+        CardinalityStatistics otherCardStat = new CardinalityStatistics();
+        for (int i = 0; i < 1000; i++) {
+            cardStats.incrementCount();
+            otherCardStat.incrementCount();
+            String str = RandomStringUtils.randomAscii(2);
+            cardStats.add(str);
+            otherCardStat.add(str);
+        }
+
+        Assert.assertEquals(true, cardStats.merge(otherCardStat));
+        // The merge should not have changed the cardinality because every element was the same for both in the loop.
+        Assert.assertEquals(cardStats.getDistinctCount(), otherCardStat.getDistinctCount());
+    }
+}

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityStatisticsTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityStatisticsTest.java
@@ -1,10 +1,11 @@
 package org.talend.dataquality.statistics.cardinality;
 
-import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 
 /**
  * Created by afournier on 31/03/17.


### PR DESCRIPTION
- Addition of AbstractCardinalityStatistics class to optimize code and create a common type for CardinalityStatistics and CardinalityHLLStatistics.
- Addition of a "merge" method to merge together two instances of Cardinality(HLL)Statistics and handle potential errors/exceptions in this method.
- Addition of Unit Tests for both classes in order to test the merge behavior and to make Sonar happy.
