### PR TITLE
TDQ-14048 Adding String.trim() for effeciency

### DIFF
--- a/dataquality-converters/src/main/java/org/talend/dataquality/converters/StringTrimmer.java
+++ b/dataquality-converters/src/main/java/org/talend/dataquality/converters/StringTrimmer.java
@@ -61,7 +61,7 @@ public class StringTrimmer {
             return inputStr;
         }
 
-        String result = inputStr;
+        String result = inputStr.trim();
         while (StringUtils.startsWithAny(result, WHITESPACE_CHARS)) {
             result = StringUtils.removeStart(result, result.substring(0, 1));
         }


### PR DESCRIPTION
The String.trim() is going to be faster in most cases, so use that method first before trimming with while-loop. If the string has a lot of white space padded, the trim() call will take care of it in 99% cases. The while loop after it is really just for very non-typical white spaces.