### PR TITLE
TDQ-13389 CardinalityStatistics can now take an Object instead of a String

### DIFF
--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/AbstractCardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/AbstractCardinalityStatistics.java
@@ -1,11 +1,13 @@
 package org.talend.dataquality.statistics.cardinality;
 
+import java.io.Serializable;
+
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 
 /**
  * Created by afournier on 31/03/17.
  */
-public abstract class AbstractCardinalityStatistics<T extends AbstractCardinalityStatistics> {
+public abstract class AbstractCardinalityStatistics<T extends AbstractCardinalityStatistics> implements Serializable {
 
     protected long count = 0;
 
@@ -29,5 +31,5 @@ public abstract class AbstractCardinalityStatistics<T extends AbstractCardinalit
 
     public abstract void merge(T other) throws CardinalityMergeException;
 
-    public abstract void add(String colStr);
+    public abstract void add(Object colObj);
 }

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatistics.java
@@ -36,8 +36,8 @@ public class CardinalityHLLStatistics extends AbstractCardinalityStatistics<Card
         return hyperLogLog.cardinality();
     }
 
-    public void add(String colStr) {
-        this.hyperLogLog.offer(colStr);
+    public void add(Object colObj) {
+        this.hyperLogLog.offer(colObj);
     }
 
     /**

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/cardinality/CardinalityStatistics.java
@@ -23,17 +23,17 @@ import java.util.Set;
  */
 public class CardinalityStatistics extends AbstractCardinalityStatistics<CardinalityStatistics> {
 
-    private final Set<String> distinctData = new HashSet<>();
+    private final Set<Object> distinctData = new HashSet<>();
 
-    public void add(String colStr) {
-        distinctData.add(colStr);
+    public void add(Object colObj) {
+        distinctData.add(colObj);
     }
 
-    public Set<String> getDistinctData() {
+    public Set<Object> getDistinctData() {
         return distinctData;
     }
 
-    private void addAll(Collection<String> col) {
+    private void addAll(Collection<Object> col) {
         this.distinctData.addAll(col);
     }
 

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatisticsTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/cardinality/CardinalityHLLStatisticsTest.java
@@ -1,11 +1,11 @@
 package org.talend.dataquality.statistics.cardinality;
 
-import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import org.apache.commons.lang.RandomStringUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
+import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 
 /**
@@ -19,6 +19,23 @@ public class CardinalityHLLStatisticsTest {
     public void setUp() throws Exception {
         cardHLLStats = new CardinalityHLLStatistics();
         cardHLLStats.setHyperLogLog(new HyperLogLog(20));
+    }
+
+    @Test
+    public void typeDifferentFromString() {
+        Integer[] ints = { 0, 2, 4, 6, 8, 8 };
+        for (Integer i : ints) {
+            cardHLLStats.add(i);
+            cardHLLStats.incrementCount();
+        }
+        Assert.assertEquals(cardHLLStats.getDistinctCount(), 5);
+
+        Double[] doubles = { 0.5, 2.5, 4.5, 6.5, 8.5, 8.5 };
+        for (Double d : doubles) {
+            cardHLLStats.add(d);
+            cardHLLStats.incrementCount();
+        }
+        Assert.assertEquals(cardHLLStats.getDistinctCount(), 10);
     }
 
     @Test(expected = CardinalityMergeException.class)

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/recognition/TypoUnicodePatternRecognizerTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/recognition/TypoUnicodePatternRecognizerTest.java
@@ -30,6 +30,15 @@ public class TypoUnicodePatternRecognizerTest {
         Assert.assertEquals("[word][Word][WORD][wORD]",
                 TypoUnicodePatternRecognizer.withCase().getValuePattern(str).toArray()[0]);
 
+        // The recursivity in the "exploreSpecial" method of the enum makes it to Recognize only one "Word" or "wORD" if
+        // capital and small letters alternates in the sequence
+        str = "WoWoWo";
+        Assert.assertEquals("[word]", TypoUnicodePatternRecognizer.noCase().getValuePattern(str).toArray()[0]);
+        Assert.assertEquals("[Word]", TypoUnicodePatternRecognizer.withCase().getValuePattern(str).toArray()[0]);
+
+        str = "wOwOwO";
+        Assert.assertEquals("[word]", TypoUnicodePatternRecognizer.noCase().getValuePattern(str).toArray()[0]);
+        Assert.assertEquals("[wORD]", TypoUnicodePatternRecognizer.withCase().getValuePattern(str).toArray()[0]);
     }
 
     @Test


### PR DESCRIPTION
The commit comprise : 
 - The generalization of Cardinality Statistics' behavior that can now analyze instances of the class Object instead of Strings only.
 - The class "AbstractCardinalityStatistics" is now Serizalizable so it can be use in distributed computing
 - A new test for the class "TypoUnicodeRecognizer" to verify the behavior in the case when capital and small letters alternates in a word.
 - New test in order to verify the behavior of CardinalityStatistics with non-String objects