### PR TITLE
Hmdebenque/fix/tdp 3858) tdq dictionnaries json serialization

### DIFF
--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/BroadcastIndexObject.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/BroadcastIndexObject.java
@@ -18,6 +18,7 @@ import java.util.*;
 
 import org.apache.log4j.Logger;
 import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.RAMDirectory;
 import org.talend.dataquality.semantic.api.CategoryRegistryManager;
 import org.talend.dataquality.semantic.model.CategoryType;
 import org.talend.dataquality.semantic.model.DQCategory;
@@ -38,7 +39,10 @@ public class BroadcastIndexObject implements Serializable {
     private List<BroadcastDocumentObject> documentList;
 
     // The lucene index created from the serializable object
-    private Directory ramDirectory;
+    private RAMDirectory ramDirectory;
+
+    public BroadcastIndexObject() {
+    }
 
     /**
      * Build an index based on a list of {@link BroadcastDocumentObject}.
@@ -97,12 +101,16 @@ public class BroadcastIndexObject implements Serializable {
         return documentList;
     }
 
+    public void setDocumentList(List<BroadcastDocumentObject> documentList) {
+        this.documentList = documentList;
+    }
+
     /**
      * The singleton method which creates the lucene index if necessary.
      * 
      * @return the lucene index
      */
-    public synchronized Directory get() {
+    public synchronized Directory asDirectory() {
         if (ramDirectory == null) {
             try {
                 ramDirectory = BroadcastUtils.createRamDirectoryFromDocuments(documentList);

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/BroadcastMetadataObject.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/BroadcastMetadataObject.java
@@ -14,14 +14,18 @@ public class BroadcastMetadataObject implements Serializable {
 
     private Map<String, DQCategory> metadata;
 
-    /**
-     * @param metadata
-     */
+    public BroadcastMetadataObject() {
+    }
+
     public BroadcastMetadataObject(Map<String, DQCategory> metadata) {
         this.metadata = metadata;
     }
 
-    public Map<String, DQCategory> get() {
+    public Map<String, DQCategory> getMetadata() {
         return metadata;
+    }
+
+    public void setMetadata(Map<String, DQCategory> metadata) {
+        this.metadata = metadata;
     }
 }

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/BroadcastRegexObject.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/BroadcastRegexObject.java
@@ -37,6 +37,10 @@ public class BroadcastRegexObject implements Serializable {
     public BroadcastRegexObject() {
     }
 
+    public BroadcastRegexObject(UserDefinedClassifier regexClassifier) {
+        this.regexClassifier = regexClassifier;
+    }
+
     public BroadcastRegexObject(UserDefinedClassifier udc, Set<String> categories) {
         this.regexClassifier = new UserDefinedClassifier();
         for (ISubCategory c : udc.getClassifiers()) {

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/BroadcastRegexObject.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/BroadcastRegexObject.java
@@ -34,17 +34,9 @@ public class BroadcastRegexObject implements Serializable {
 
     private UserDefinedClassifier regexClassifier;
 
-    /**
-     * @param regexClassifier
-     */
-    public BroadcastRegexObject(UserDefinedClassifier regexClassifier) {
-        this.regexClassifier = regexClassifier;
+    public BroadcastRegexObject() {
     }
 
-    /**
-     * @param udc
-     * @param categories
-     */
     public BroadcastRegexObject(UserDefinedClassifier udc, Set<String> categories) {
         this.regexClassifier = new UserDefinedClassifier();
         for (ISubCategory c : udc.getClassifiers()) {
@@ -54,9 +46,6 @@ public class BroadcastRegexObject implements Serializable {
         }
     }
 
-    /**
-     * @param regexPath
-     */
     public BroadcastRegexObject(URI regexPath) {
         try {
             this.regexClassifier = UDCategorySerDeser.readJsonFile(regexPath);
@@ -65,8 +54,11 @@ public class BroadcastRegexObject implements Serializable {
         }
     }
 
-    public UserDefinedClassifier get() {
+    public UserDefinedClassifier getRegexClassifier() {
         return regexClassifier;
     }
 
+    public void setRegexClassifier(UserDefinedClassifier regexClassifier) {
+        this.regexClassifier = regexClassifier;
+    }
 }

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/BroadcastUtils.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/BroadcastUtils.java
@@ -92,7 +92,7 @@ class BroadcastUtils {
     /**
      * create a lucene RAMDirectory from a list of BroadcastDocumentObject
      */
-    static Directory createRamDirectoryFromDocuments(List<BroadcastDocumentObject> dictionaryObject) throws IOException {
+    static RAMDirectory createRamDirectoryFromDocuments(List<BroadcastDocumentObject> dictionaryObject) throws IOException {
         RAMDirectory ramDirectory = new RAMDirectory();
         IndexWriterConfig writerConfig = new IndexWriterConfig(Version.LATEST, new StandardAnalyzer(CharArraySet.EMPTY_SET));
         IndexWriter writer = new IndexWriter(ramDirectory, writerConfig);

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/TdqCategories.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/broadcast/TdqCategories.java
@@ -9,44 +9,55 @@ public class TdqCategories implements Serializable {
 
     private static final long serialVersionUID = 8077049508746278932L;
 
-    private final BroadcastMetadataObject metadata;
+    private BroadcastMetadataObject categoryMetadata;
 
-    private final BroadcastIndexObject dictionary;
+    private BroadcastIndexObject dictionary;
 
-    private final BroadcastIndexObject keyword;
+    private BroadcastIndexObject keyword;
 
-    private final BroadcastRegexObject regex;
+    private BroadcastRegexObject regex;
 
-    /**
-     * Constructor
-     * 
-     * @param metadata
-     * @param dictionary
-     * @param keyword
-     * @param regex
-     */
-    public TdqCategories(BroadcastMetadataObject metadata, BroadcastIndexObject dictionary, BroadcastIndexObject keyword,
+    public TdqCategories() {
+    }
+
+    public TdqCategories(BroadcastMetadataObject categoryMetadata, BroadcastIndexObject dictionary, BroadcastIndexObject keyword,
             BroadcastRegexObject regex) {
-        this.metadata = metadata;
+        this.categoryMetadata = categoryMetadata;
         this.dictionary = dictionary;
         this.keyword = keyword;
         this.regex = regex;
     }
 
     public BroadcastMetadataObject getCategoryMetadata() {
-        return metadata;
+        return categoryMetadata;
+    }
+
+    public void setCategoryMetadata(BroadcastMetadataObject categoryMetadata) {
+        this.categoryMetadata = categoryMetadata;
     }
 
     public BroadcastIndexObject getDictionary() {
         return dictionary;
     }
 
+    public void setDictionary(BroadcastIndexObject dictionary) {
+        this.dictionary = dictionary;
+    }
+
     public BroadcastIndexObject getKeyword() {
         return keyword;
     }
 
+    public void setKeyword(BroadcastIndexObject keyword) {
+        this.keyword = keyword;
+    }
+
     public BroadcastRegexObject getRegex() {
         return regex;
+    }
+
+    public void setRegex(BroadcastRegexObject regex) {
+        this.regex = regex;
     }
 
 }

--- a/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/broadcast/BroadcastIndexObjectTest.java
+++ b/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/broadcast/BroadcastIndexObjectTest.java
@@ -12,8 +12,6 @@
 // ============================================================================
 package org.talend.dataquality.semantic.broadcast;
 
-import static org.junit.Assert.assertEquals;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -37,6 +35,8 @@ import org.talend.dataquality.semantic.api.DictionaryUtils;
 import org.talend.dataquality.semantic.index.ClassPathDirectory;
 import org.talend.dataquality.semantic.index.DictionarySearcher;
 
+import static org.junit.Assert.assertEquals;
+
 public class BroadcastIndexObjectTest {
 
     private static final Map<String, String[]> TEST_INDEX_CONTENT = new LinkedHashMap<String, String[]>() {
@@ -56,7 +56,7 @@ public class BroadcastIndexObjectTest {
         final BroadcastDocumentObject object = new BroadcastDocumentObject("CATEGORY", Collections.singleton("Value"));
         final BroadcastIndexObject bio = new BroadcastIndexObject(Collections.singletonList(object));
 
-        try (Directory directory = bio.get()) { // when
+        try (Directory directory = bio.asDirectory()) { // when
             // then
             DirectoryReader directoryReader = DirectoryReader.open(directory);
             Document ramDoc = directoryReader.document(0);
@@ -108,7 +108,7 @@ public class BroadcastIndexObjectTest {
         final Directory cpDir = ClassPathDirectory.open(testFolder.toURI());
         final BroadcastIndexObject bio = new BroadcastIndexObject(cpDir, true);
         // get the RamDirectory from BroadcastIndexObject
-        final Directory ramDir = bio.get();
+        final Directory ramDir = bio.asDirectory();
 
         // assertions
         try {

--- a/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/broadcast/BroadcastRegexObjectTest.java
+++ b/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/broadcast/BroadcastRegexObjectTest.java
@@ -12,12 +12,12 @@
 // ============================================================================
 package org.talend.dataquality.semantic.broadcast;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-
 import org.junit.Test;
 import org.talend.dataquality.semantic.api.CategoryRegistryManager;
 import org.talend.dataquality.semantic.classifier.custom.UserDefinedClassifier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 public class BroadcastRegexObjectTest {
 
@@ -27,7 +27,7 @@ public class BroadcastRegexObjectTest {
         final BroadcastRegexObject bro = new BroadcastRegexObject(CategoryRegistryManager.getInstance().getRegexURI());
 
         // when
-        UserDefinedClassifier regex = bro.get();
+        UserDefinedClassifier regex = bro.getRegexClassifier();
 
         // then
         assertNotNull(regex);

--- a/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/broadcast/TdqCategoriesFactoryTest.java
+++ b/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/broadcast/TdqCategoriesFactoryTest.java
@@ -1,14 +1,13 @@
 package org.talend.dataquality.semantic.broadcast;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
 import org.apache.lucene.index.MultiFields;
@@ -21,6 +20,8 @@ import org.talend.dataquality.semantic.classifier.custom.UserDefinedClassifier;
 import org.talend.dataquality.semantic.index.DictionarySearcher;
 import org.talend.dataquality.semantic.model.DQCategory;
 
+import static org.junit.Assert.*;
+
 public class TdqCategoriesFactoryTest {
 
     @Test
@@ -28,7 +29,7 @@ public class TdqCategoriesFactoryTest {
         Collection<DQCategory> expectedCategories = CategoryRegistryManager.getInstance().listCategories(false);
         TdqCategories cats = TdqCategoriesFactory.createTdqCategories();
 
-        Map<String, DQCategory> meta = cats.getCategoryMetadata().get();
+        Map<String, DQCategory> meta = cats.getCategoryMetadata().getMetadata();
         assertEquals("Unexpected metadata size!", 75, meta.values().size());
 
         for (DQCategory value : expectedCategories) {
@@ -41,12 +42,12 @@ public class TdqCategoriesFactoryTest {
         TdqCategories cats = TdqCategoriesFactory.createTdqCategories(
                 new HashSet<String>(Arrays.asList(new String[] { SemanticCategoryEnum.STREET_TYPE.name() })));
 
-        Map<String, DQCategory> meta = cats.getCategoryMetadata().get();
+        Map<String, DQCategory> meta = cats.getCategoryMetadata().getMetadata();
         assertEquals("Unexpected metadata size!", 1, meta.values().size());
         assertTrue("Unexpected category found in metadata",
                 meta.keySet().contains(SemanticCategoryEnum.STREET_TYPE.getTechnicalId()));
 
-        Directory ramDir = cats.getDictionary().get();
+        Directory ramDir = cats.getDictionary().asDirectory();
         DirectoryReader reader = DirectoryReader.open(ramDir);
         Bits liveDocs = MultiFields.getLiveDocs(reader);
         assertEquals("Unexpected document count!", 18, reader.maxDoc());
@@ -63,18 +64,32 @@ public class TdqCategoriesFactoryTest {
     @Test
     public void testCreateTdqCategoriesWithSpecifiedRegexCategory() throws IOException {
         TdqCategories cats = TdqCategoriesFactory
-                .createTdqCategories(new HashSet<String>(Arrays.asList(new String[] { SemanticCategoryEnum.EMAIL.name() })));
+                .createTdqCategories(new HashSet<>(Arrays.asList(new String[] { SemanticCategoryEnum.EMAIL.name() })));
 
-        Map<String, DQCategory> meta = cats.getCategoryMetadata().get();
+        Map<String, DQCategory> meta = cats.getCategoryMetadata().getMetadata();
         assertEquals("Unexpected metadata size!", 1, meta.values().size());
         assertTrue("Unexpected category found in metadata", meta.keySet().contains(SemanticCategoryEnum.EMAIL.getTechnicalId()));
 
-        Directory ramDir = cats.getDictionary().get();
+        Directory ramDir = cats.getDictionary().asDirectory();
         DirectoryReader reader = DirectoryReader.open(ramDir);
         assertEquals("Unexpected document count!", 0, reader.maxDoc());
 
-        UserDefinedClassifier udc = cats.getRegex().get();
+        UserDefinedClassifier udc = cats.getRegex().getRegexClassifier();
         assertEquals("Unexpected classifier count!", 1, udc.getClassifiers().size());
         assertEquals("Unexpected classifier name!", "EMAIL", udc.getClassifiers().iterator().next().getName());
+    }
+    
+    @Test
+    public void testSerializable() throws Exception {
+        TdqCategories baseValue = TdqCategoriesFactory
+                .createTdqCategories(new HashSet<>(Arrays.asList(new String[] { SemanticCategoryEnum.EMAIL.name() })));
+
+        ObjectMapper mapper = new ObjectMapper();
+        try {
+            String stringVersion = mapper.writeValueAsString(baseValue);
+            mapper.readValue(stringVersion, TdqCategories.class);
+        } catch (JsonProcessingException jsonProcessingException) {
+            fail("Cannot serialize " + TdqCategories.class + " exception was: " + jsonProcessingException);
+        }
     }
 }

--- a/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/broadcast/TdqCategoriesFactoryTest.java
+++ b/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/broadcast/TdqCategoriesFactoryTest.java
@@ -78,7 +78,7 @@ public class TdqCategoriesFactoryTest {
         assertEquals("Unexpected classifier count!", 1, udc.getClassifiers().size());
         assertEquals("Unexpected classifier name!", "EMAIL", udc.getClassifiers().iterator().next().getName());
     }
-    
+
     @Test
     public void testSerializable() throws Exception {
         TdqCategories baseValue = TdqCategoriesFactory


### PR DESCRIPTION
Updates TDQ dictionaries classes to make them instantiable with an empty constructor as Jackson need to deserialize this classes.

bound to DataPrep Jira: https://jira.talendforge.org/browse/TDP-3858
