### PR TITLE
fix(manage multiple metadata package in classpath)

### DIFF
--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/api/CategoryRegistryManager.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/api/CategoryRegistryManager.java
@@ -18,8 +18,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -153,7 +155,7 @@ public class CategoryRegistryManager {
             usingLocalCategoryRegistry = true;
             instance = new CategoryRegistryManager();
         } else {
-            LOGGER.warn("Cannot set an empty path as local registy location. Use default one: " + localRegistryPath);
+            LOGGER.warn("Cannot set an empty path as local registry location. Use default one: " + localRegistryPath);
         }
     }
 
@@ -253,12 +255,43 @@ public class CategoryRegistryManager {
 
     private void loadBaseIndex(final File destSubFolder, String sourceSubFolder) throws IOException, URISyntaxException {
         synchronized (indexExtractionLock) {
+
+            // extract base index only if needed
             if (!destSubFolder.exists()) {
-                final URI indexSourceURI = this.getClass().getResource("/" + sourceSubFolder).toURI();
-                try (final Directory srcDir = ClassPathDirectory.open(indexSourceURI)) {
-                    if (usingLocalCategoryRegistry && !destSubFolder.exists()) {
-                        DictionaryUtils.rewriteIndex(srcDir, destSubFolder);
+
+                boolean baseIndexExtracted = false;
+
+                // because the classpath can have multiple 'metadata' packages (especially with spring boot uber jar packaging)
+                // we need to iterate over the potential resources
+                final List<URL> potentialResources = Collections
+                        .list(this.getClass().getClassLoader().getResources(sourceSubFolder));
+                for (URL url : potentialResources) {
+
+                    final URI uri = url.toURI();
+                    LOGGER.debug("trying to load base index from " + uri.toString());
+
+                    // try the potential resource one by one
+                    try (final Directory srcDir = ClassPathDirectory.open(uri)) {
+                        if (usingLocalCategoryRegistry && !destSubFolder.exists()) {
+                            DictionaryUtils.rewriteIndex(srcDir, destSubFolder);
+                            // if successful, let's not try the remaining ones
+                            LOGGER.info("base index loaded from " + uri.toString());
+                            baseIndexExtracted = true;
+                            break;
+                        }
+                    } catch (IllegalArgumentException iae) {
+                        // that's expected as multiple 'metadata' packages can exist within the classpath
+                        LOGGER.debug("could not load base index from " + uri.toString());
                     }
+                }
+
+                // if base index could not be loaded, let's make a nice error message
+                if (!baseIndexExtracted) {
+                    final StringBuilder error = new StringBuilder(100);
+                    error.append("Could not load base index out of theses locations : [\n");
+                    potentialResources.forEach(pr -> error.append('\t').append(pr.toString()).append('\n'));
+                    error.append(']');
+                    throw new IllegalArgumentException(error.toString());
                 }
             }
         }

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/api/CategoryRegistryManager.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/api/CategoryRegistryManager.java
@@ -286,7 +286,7 @@ public class CategoryRegistryManager {
                 }
 
                 // if base index could not be loaded, let's make a nice error message
-                if (!baseIndexExtracted) {
+                if (usingLocalCategoryRegistry && !destSubFolder.exists() && !baseIndexExtracted) {
                     final StringBuilder error = new StringBuilder(100);
                     error.append("Could not load base index out of theses locations : [\n");
                     potentialResources.forEach(pr -> error.append('\t').append(pr.toString()).append('\n'));


### PR DESCRIPTION
* because multiple 'metadata' packages can be found in the classpath (especially with spring boot uber jar packaging) the 'load base index' method now iterates over potential urls trying them one by one until it works.

This prevent the following error
Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.talend.dataprep.quality.AnalyzerService]: Factory method 'analyzerService' threw exception; nested exception is java.lang.IllegalArgumentException: Unable to open JAR 'jar:file:/service.jar!/BOOT-INF/classes/org/talend/dataprep/dataset/store!/metadata'.
    at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:189)
    at org.springframework.beans.factory.support.ConstructorResolver.instantiateUsingFactoryMethod(ConstructorResolver.java:588)
    ... 39 common frames omitted
Caused by: java.lang.IllegalArgumentException: Unable to open JAR 'jar:file:/service.jar!/BOOT-INF/classes/org/talend/dataprep/dataset/store!/metadata'.
    at org.talend.dataquality.semantic.index.ClassPathDirectory.open(ClassPathDirectory.java:87)
    at org.talend.dataquality.semantic.api.CategoryRegistryManager.loadBaseIndex(CategoryRegistryManager.java:258)
    at org.talend.dataquality.semantic.api.CategoryRegistryManager.loadRegisteredCategories(CategoryRegistryManager.java:206)
    at org.talend.dataquality.semantic.api.CategoryRegistryManager.<init>(CategoryRegistryManager.java:115)
    at org.talend.dataquality.semantic.api.CategoryRegistryManager.setLocalRegistryPath(CategoryRegistryManager.java:154)
    at org.talend.dataprep.quality.AnalyzerService.<init>(AnalyzerService.java:103)
    at org.talend.dataprep.configuration.Analyzers.analyzerService(Analyzers.java:52)
    at org.talend.dataprep.configuration.Analyzers$$EnhancerBySpringCGLIB$$5fad76fd.CGLIB$analyzerService$0(<generated>)
    at org.talend.dataprep.configuration.Analyzers$$EnhancerBySpringCGLIB$$5fad76fd$$FastClassBySpringCGLIB$$c0eaae64.invoke(<generated>)
    at org.springframework.cglib.proxy.MethodProxy.invokeSuper(MethodProxy.java:228)
    at org.springframework.context.annotation.ConfigurationClassEnhancer$BeanMethodInterceptor.intercept(ConfigurationClassEnhancer.java:358)
    at org.talend.dataprep.configuration.Analyzers$$EnhancerBySpringCGLIB$$5fad76fd.analyzerService(<generated>)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
    at org.springframework.beans.factory.support.SimpleInstantiationStrategy.instantiate(SimpleInstantiationStrategy.java:162)
    ... 40 common frames omitted
Caused by: java.nio.file.ProviderNotFoundException: Provider not found
    at java.nio.file.FileSystems.newFileSystem(FileSystems.java:407)
    at org.talend.dataquality.semantic.index.ClassPathDirectory$BasicProvider.get(ClassPathDirectory.java:220)
    at org.talend.dataquality.semantic.index.ClassPathDirectory$SingletonProvider.get(ClassPathDirectory.java:147)
    at org.talend.dataquality.semantic.index.ClassPathDirectory.open(ClassPathDirectory.java:85)
    ... 56 common frames omitted