### PR TITLE
fix TDQ-14218 NULL exist in the data, "Shortest (for strings)" in

### DIFF
--- a/dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/mfb/MFBRecordMerger.java
+++ b/dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/mfb/MFBRecordMerger.java
@@ -106,8 +106,13 @@ public class MFBRecordMerger implements IRecordMerger {
             String mergedValue, AttributeValues<String> mergedValues) {
         BigDecimal leftNumberValue;
         BigDecimal rightNumberValue;
-        int leftValueLength = leftValue == null ? 0 : leftValue.length();
-        int rightValueLength = rightValue == null ? 0 : rightValue.length();
+        if (leftValue == null) {
+            return rightValue;
+        } else if (rightValue == null) {
+            return leftValue;
+        }
+        int leftValueLength = leftValue.length();
+        int rightValueLength = rightValue.length();
         switch (survivorShipAlgorithmEnum) {
         case CONCATENATE:
             if (StringUtils.isEmpty(parameter)) {

--- a/dataquality-record-linkage/src/test/java/org/talend/dataquality/record/linkage/grouping/SwooshRecordGroupingTest.java
+++ b/dataquality-record-linkage/src/test/java/org/talend/dataquality/record/linkage/grouping/SwooshRecordGroupingTest.java
@@ -2160,12 +2160,99 @@ public class SwooshRecordGroupingTest {
         Assert.assertTrue(groupRows_tMatchGroup_1.size() > 0);
         for (row2Struct one : groupRows_tMatchGroup_1) {
             if (one.MASTER) {
-                Assert.assertEquals("12", one.city);
+                Assert.assertEquals("900", one.city);
 
                 break;
             }
         }
 
+    }
+
+    @Test
+    public void testSwooshIntMatchGroup_tdq14218mergeNULL()
+            throws IOException, InterruptedException, InstantiationException, IllegalAccessException, ClassNotFoundException {
+        List<List<Map<String, String>>> matchingRulesAll_tMatchGroup_1 = new ArrayList<List<Map<String, String>>>();
+        List<Map<String, String>> matcherList_tMatchGroup_1 = null;
+        Map<String, String> tmpMap_tMatchGroup_1 = null;
+
+        List<Map<String, String>> defaultSurvivorshipRules_tMatchGroup_1 = new ArrayList<Map<String, String>>();
+        Map<String, String> realSurShipMap_tMatchGroup_1 = null;
+        realSurShipMap_tMatchGroup_1 = new HashMap<String, String>();
+        realSurShipMap_tMatchGroup_1.put("PARAMETER", "");
+        realSurShipMap_tMatchGroup_1.put("SURVIVORSHIP_FUNCTION", "Shortest");
+        realSurShipMap_tMatchGroup_1.put("DATA_TYPE", "STRING");
+        defaultSurvivorshipRules_tMatchGroup_1.add(realSurShipMap_tMatchGroup_1);
+
+        matcherList_tMatchGroup_1 = new ArrayList<Map<String, String>>();
+        tmpMap_tMatchGroup_1 = createTmpMap("CONCATENATE", "1", "", "country", "2", "Exact", "NO", 1 + "", "nullMatchNull",
+                0.85 + "", "TSWOOSH_MATCHER");
+        matcherList_tMatchGroup_1.add(tmpMap_tMatchGroup_1);
+        matchingRulesAll_tMatchGroup_1.add(matcherList_tMatchGroup_1);
+
+        // master rows in a group
+        final List<row2Struct> masterRows_tMatchGroup_1 = new ArrayList<row2Struct>();
+        // all rows in a group
+        final List<row2Struct> groupRows_tMatchGroup_1 = new ArrayList<row2Struct>();
+        // this Map key is MASTER GID,value is this MASTER index of all
+        // MASTERS.it will be used to get DUPLICATE GRP_QUALITY from
+        // MASTER and only in case of separate output.
+        final Map<String, Integer> indexMap_tMatchGroup_1 = new HashMap<String, Integer>();
+
+        // TDQ-9172 reuse JAVA API at here.
+        AbstractRecordGrouping<Object> recordGroupImp_tMatchGroup_1 = createComponent(masterRows_tMatchGroup_1,
+                groupRows_tMatchGroup_1, indexMap_tMatchGroup_1);
+
+        recordGroupImp_tMatchGroup_1.setRecordLinkAlgorithm(RecordMatcherType.T_SwooshAlgorithm);
+        // add mutch rules
+        for (List<Map<String, String>> matcherList : matchingRulesAll_tMatchGroup_1) {
+            recordGroupImp_tMatchGroup_1.addMatchRule(matcherList);
+        }
+        recordGroupImp_tMatchGroup_1.initialize();
+        // init the parameters of the tswoosh algorithm
+        Map<String, String> columnWithType_tMatchGroup_1 = fillColumn("id_Integer", "id_String", "id_String", "id_String",
+                "id_Integer", "id_Boolean", "id_Double", "id_Double", null);
+        Map<String, String> columnWithIndex_tMatchGroup_1 = fillColumn("0", "1", "2", "3", "4", "5", "6", "7", null);
+
+        SurvivorShipAlgorithmParams survivorShipAlgorithmParams_tMatchGroup_1 = SurvivorshipUtils
+                .createSurvivorShipAlgorithmParams((AnalysisSwooshMatchRecordGrouping) recordGroupImp_tMatchGroup_1,
+                        matchingRulesAll_tMatchGroup_1, defaultSurvivorshipRules_tMatchGroup_1, columnWithType_tMatchGroup_1,
+                        columnWithIndex_tMatchGroup_1);
+        ((AnalysisSwooshMatchRecordGrouping) recordGroupImp_tMatchGroup_1)
+                .setSurvivorShipAlgorithmParams(survivorShipAlgorithmParams_tMatchGroup_1);
+        initialize(recordGroupImp_tMatchGroup_1);
+
+        // read the data from the file
+        InputStream in = this.getClass().getResourceAsStream("tdq11599.txt"); //$NON-NLS-1$
+        BufferedReader bfr = new BufferedReader(new InputStreamReader(in));
+        List<String> listOfLines = IOUtils.readLines(bfr);
+        inputList = new ArrayList<String[]>();
+        for (String line : listOfLines) {
+            String[] fields = StringUtils.splitPreserveAllTokens(line, columnDelimiter);
+            int i = 0;
+            for (String str : fields) {
+                if ("null".equals(str) || "".equals(str)) {
+                    fields[i] = null;
+                }
+                i++;
+            }
+            inputList.add(fields);
+        }
+
+        for (String[] inputRow : inputList) { // loop on each data
+            recordGroupImp_tMatchGroup_1.doGroup(inputRow);
+        } // while
+
+        recordGroupImp_tMatchGroup_1.end();
+        groupRows_tMatchGroup_1.addAll(masterRows_tMatchGroup_1);
+
+        Collections.sort(groupRows_tMatchGroup_1);
+        Assert.assertTrue(groupRows_tMatchGroup_1.size() > 0);
+        for (row2Struct one : groupRows_tMatchGroup_1) {
+            if (one.MASTER) {
+                Assert.assertEquals("1", one.city);
+                break;
+            }
+        }
     }
 
     private Map<String, String> createTmpMap(String survivorShipFunction, String attributeThresold, String parameter,

--- a/dataquality-record-linkage/src/test/resources/org/talend/dataquality/record/linkage/grouping/tdq11599.txt
+++ b/dataquality-record-linkage/src/test/resources/org/talend/dataquality/record/linkage/grouping/tdq11599.txt
@@ -1,5 +1,5 @@
-0|3|Mexico
-1|9|Mexico
+0|33|Mexico
+1|900|Mexico
 7|12|Mexico
 8|1|Mexico
 13||Mexico


### PR DESCRIPTION
Survivorship Function get this as master value, should not

- ignore the null value when merge
- add junit case