### PR TITLE
fix(TDP-5857) On CSV file with empty column, action "Remove trailing and leading characters" on whitespaces badly applied after actions generating leading/trailing whitespaces

### DIFF
--- a/dataquality-converters/src/main/java/org/talend/dataquality/converters/StringTrimmer.java
+++ b/dataquality-converters/src/main/java/org/talend/dataquality/converters/StringTrimmer.java
@@ -65,10 +65,10 @@ public class StringTrimmer {
         char currentCharacter = inputStr.charAt(startIndex);
         while (startIndex < endIndex
                 && (currentCharacter <= ' ' || WHITESPACE_CHARS_SUPERIOR_ASCII_SPACE.contains(currentCharacter))) {
-            currentCharacter = inputStr.charAt(++startIndex);
+            if (++startIndex == endIndex)
+                return "";
+            currentCharacter = inputStr.charAt(startIndex);
         }
-        if (startIndex == endIndex)
-            return "";
         do {
             currentCharacter = inputStr.charAt(--endIndex);
         } while (currentCharacter <= ' ' || WHITESPACE_CHARS_SUPERIOR_ASCII_SPACE.contains(currentCharacter));
@@ -132,10 +132,10 @@ public class StringTrimmer {
         int endIndex = inputStr.length();
         char currentCharacter = inputStr.charAt(startIndex);
         while (startIndex < endIndex && (currentCharacter == removeCharacter)) {
-            currentCharacter = inputStr.charAt(++startIndex);
+            if (++startIndex == endIndex)
+                return "";
+            currentCharacter = inputStr.charAt(startIndex);
         }
-        if (startIndex == endIndex)
-            return "";
         do {
             currentCharacter = inputStr.charAt(--endIndex);
         } while (currentCharacter == removeCharacter);

--- a/dataquality-converters/src/main/java/org/talend/dataquality/converters/StringTrimmer.java
+++ b/dataquality-converters/src/main/java/org/talend/dataquality/converters/StringTrimmer.java
@@ -55,25 +55,25 @@ public class StringTrimmer {
      * @param inputStr - the input text.
      * @return String
      */
-    public String removeTrailingAndLeadingWhitespaces(String inputStr) {
+    public String removeTrailingAndLeadingWhitespaces(final String inputStr) {
         if (StringUtils.isEmpty(inputStr)) {
-            return inputStr;
+            return "";
         }
 
-        int startIndex = 0;
-        int endIndex = inputStr.length();
-        char currentCharacter = inputStr.charAt(startIndex);
-        while (startIndex < endIndex
-                && (currentCharacter <= ' ' || WHITESPACE_CHARS_SUPERIOR_ASCII_SPACE.contains(currentCharacter))) {
-            if (++startIndex == endIndex)
-                return "";
-            currentCharacter = inputStr.charAt(startIndex);
-        }
-        do {
-            currentCharacter = inputStr.charAt(--endIndex);
-        } while (currentCharacter <= ' ' || WHITESPACE_CHARS_SUPERIOR_ASCII_SPACE.contains(currentCharacter));
+        int len = inputStr.length();
+        int startIndex = 0;/* avoid getfield opcode */
 
-        return inputStr.substring(startIndex, endIndex + 1);
+        while ((startIndex < len) && (mustBeRemoved(inputStr.charAt(startIndex)))) {
+            startIndex++;
+        }
+        while ((startIndex < len) && (mustBeRemoved(inputStr.charAt(len - 1)))) {
+            len--;
+        }
+        return ((startIndex > 0) || (len < inputStr.length())) ? inputStr.substring(startIndex, len) : inputStr;
+    }
+
+    private boolean mustBeRemoved(final char c) {
+        return c <= ' ' || (WHITESPACE_CHARS_SUPERIOR_ASCII_SPACE.contains(c));
     }
 
     /**
@@ -93,7 +93,7 @@ public class StringTrimmer {
     /**
      * Remove trailing and leading characters.
      *
-     * @param inputStr - the input text.
+     * @param inputStr  - the input text.
      * @param removeStr - the remove string.
      * @return String.
      */
@@ -125,21 +125,19 @@ public class StringTrimmer {
      */
     public String removeTrailingAndLeading(String inputStr, Character removeCharacter) {
         if (StringUtils.isEmpty(inputStr)) {
-            return inputStr;
+            return "";
         }
 
+        int len = inputStr.length();
         int startIndex = 0;
-        int endIndex = inputStr.length();
-        char currentCharacter = inputStr.charAt(startIndex);
-        while (startIndex < endIndex && (currentCharacter == removeCharacter)) {
-            if (++startIndex == endIndex)
-                return "";
-            currentCharacter = inputStr.charAt(startIndex);
-        }
-        do {
-            currentCharacter = inputStr.charAt(--endIndex);
-        } while (currentCharacter == removeCharacter);
+        char[] val = inputStr.toCharArray(); /* avoid getfield opcode */
 
-        return inputStr.substring(startIndex, endIndex + 1);
+        while ((startIndex < len) && (removeCharacter == (val[startIndex]))) {
+            startIndex++;
+        }
+        while ((startIndex < len) && (removeCharacter == (val[len - 1]))) {
+            len--;
+        }
+        return ((startIndex > 0) || (len < inputStr.length())) ? inputStr.substring(startIndex, len) : inputStr;
     }
 }

--- a/dataquality-converters/src/test/java/org/talend/dataquality/converters/StringTrimmerTest.java
+++ b/dataquality-converters/src/test/java/org/talend/dataquality/converters/StringTrimmerTest.java
@@ -85,6 +85,8 @@ public class StringTrimmerTest {
         assertEquals("a b c", stringTrimmer.removeTrailingAndLeading(" a b c ")); //$NON-NLS-1$ //$NON-NLS-2$
 
         // test for other characters
+        assertEquals("", stringTrimmer.removeTrailingAndLeading("aaa", "a")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("", stringTrimmer.removeTrailingAndLeading("\t", "\t")); //$NON-NLS-1$ //$NON-NLS-2$
         assertEquals(expected, stringTrimmer.removeTrailingAndLeading("\t" + expected, "\t")); //$NON-NLS-1$ //$NON-NLS-2$
         assertEquals(expected, stringTrimmer.removeTrailingAndLeading(expected + "\t", "\t")); //$NON-NLS-1$ //$NON-NLS-2$
         assertEquals(expected, stringTrimmer.removeTrailingAndLeading('\u0009' + expected, "\t")); //$NON-NLS-1$
@@ -119,6 +121,16 @@ public class StringTrimmerTest {
             inputData = inputData + removechar;
         }
         assertEquals(expected, stringTrimmer.removeTrailingAndLeadingWhitespaces(inputData));
+        inputData = ""; //$NON-NLS-1$
+        for (String removechar : WHITESPACE_CHARS) {
+            inputData = inputData + removechar;
+        }
+        inputData = inputData + expected + " ";
+        assertEquals(expected, stringTrimmer.removeTrailingAndLeadingWhitespaces(inputData));
+        assertEquals("", stringTrimmer.removeTrailingAndLeadingWhitespaces("  ")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("a", stringTrimmer.removeTrailingAndLeadingWhitespaces(" a ")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("a", stringTrimmer.removeTrailingAndLeadingWhitespaces("a ")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("a", stringTrimmer.removeTrailingAndLeadingWhitespaces(" a")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test

--- a/dataquality-converters/src/test/java/org/talend/dataquality/converters/StringTrimmerTest.java
+++ b/dataquality-converters/src/test/java/org/talend/dataquality/converters/StringTrimmerTest.java
@@ -131,6 +131,7 @@ public class StringTrimmerTest {
         assertEquals("a", stringTrimmer.removeTrailingAndLeadingWhitespaces(" a ")); //$NON-NLS-1$ //$NON-NLS-2$
         assertEquals("a", stringTrimmer.removeTrailingAndLeadingWhitespaces("a ")); //$NON-NLS-1$ //$NON-NLS-2$
         assertEquals("a", stringTrimmer.removeTrailingAndLeadingWhitespaces(" a")); //$NON-NLS-1$ //$NON-NLS-2$
+        assertEquals("a", stringTrimmer.removeTrailingAndLeadingWhitespaces("   a   ")); //$NON-NLS-1$ //$NON-NLS-2$
     }
 
     @Test


### PR DESCRIPTION
Fix the bug:
StringTrimmer.removeTrailingAndLeadingWhitespaces(" ") and
StringTrimmer.removeTrailingAndLeading("aaa", "a")  throw an exception.