### PR TITLE
fix(TDP-6249): fix between indexes keep

### DIFF
--- a/dataquality-sampling/src/main/java/org/talend/dataquality/datamasking/functions/BetweenIndexesKeep.java
+++ b/dataquality-sampling/src/main/java/org/talend/dataquality/datamasking/functions/BetweenIndexesKeep.java
@@ -12,8 +12,10 @@
 // ============================================================================
 package org.talend.dataquality.datamasking.functions;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
- * created by jgonzalez on 22 juin 2015. This class is used when the requested function is BetweenIndexesKeep. It will
+ * created by jgonzalez on June 22, 2015. This class is used when the requested function is BetweenIndexesKeep. It will
  * return a new String that only contains the input elements that are between the bounds given as parameter.
  *
  */
@@ -30,10 +32,11 @@ public class BetweenIndexesKeep extends BetweenIndexes {
 
     @Override
     protected String doGenerateMaskedField(String str) {
-        if (!isValidParameters || str == null)
+        final int length = str.length();
+        if (!isValidParameters || StringUtils.isEmpty(str) || beginIndex > length)
             return getDefaultOutput();
-        if (endIndex > str.length())
-            return getDefaultOutput();
+        if (endIndex > length)
+            endIndex = length;
         return str.substring(beginIndex, endIndex);
     }
 

--- a/dataquality-sampling/src/main/java/org/talend/dataquality/datamasking/functions/BetweenIndexesKeep.java
+++ b/dataquality-sampling/src/main/java/org/talend/dataquality/datamasking/functions/BetweenIndexesKeep.java
@@ -32,11 +32,10 @@ public class BetweenIndexesKeep extends BetweenIndexes {
 
     @Override
     protected String doGenerateMaskedField(String str) {
-        final int length = str.length();
-        if (!isValidParameters || StringUtils.isEmpty(str) || beginIndex > length)
+        if (!isValidParameters || StringUtils.isEmpty(str) || beginIndex > str.length())
             return getDefaultOutput();
-        if (endIndex > length)
-            endIndex = length;
+        if (endIndex > str.length())
+            endIndex = str.length();
         return str.substring(beginIndex, endIndex);
     }
 

--- a/dataquality-sampling/src/test/java/org/talend/dataquality/datamasking/functions/BetweenIndexesKeepTest.java
+++ b/dataquality-sampling/src/test/java/org/talend/dataquality/datamasking/functions/BetweenIndexesKeepTest.java
@@ -102,4 +102,11 @@ public class BetweenIndexesKeepTest {
         output = bik.generateMaskedRow(input);
         assertEquals("e", output);
     }
+
+    @Test
+    public void testWithNullInput() {
+        bik.parse("5,452", false, new Random(42));
+        output = bik.generateMaskedRow(null);
+        assertEquals("", output);
+    }
 }

--- a/dataquality-sampling/src/test/java/org/talend/dataquality/datamasking/functions/BetweenIndexesKeepTest.java
+++ b/dataquality-sampling/src/test/java/org/talend/dataquality/datamasking/functions/BetweenIndexesKeepTest.java
@@ -95,4 +95,11 @@ public class BetweenIndexesKeepTest {
         output = bik.generateMaskedRow(input);
         assertEquals("", output);
     }
+
+    @Test
+    public void TDP6249() {
+        bik.parse("5,452", false, new Random(42));
+        output = bik.generateMaskedRow(input);
+        assertEquals("e", output);
+    }
 }


### PR DESCRIPTION
This PR fix the algorithm of BetweenIndexesKeep in order to follow the expected behavior.
https://jira.talendforge.org/browse/TDP-6249