### PR TITLE
fix(TDQ-16112): avoid NPE when calling listDocuments on a DICT category with no …

### DIFF
--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/api/CustomDictionaryHolder.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/api/CustomDictionaryHolder.java
@@ -209,6 +209,8 @@ public class CustomDictionaryHolder {
     public void createCategory(DQCategory category) {
         if (CategoryType.REGEX.equals(category.getType())) {
             insertOrUpdateRegexCategory(category);
+        } else if (CategoryType.DICT.equals(category.getType())) {
+            ensureDocumentDictIndexAccess();
         }
         category.setModified(true);
         ensureMetadataIndexAccess();

--- a/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/api/LocalDictionaryCacheTest.java
+++ b/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/api/LocalDictionaryCacheTest.java
@@ -267,4 +267,20 @@ public class LocalDictionaryCacheTest extends CategoryRegistryManagerAbstract {
 
         System.out.println("Found " + aux.size() + " values in " + SemanticCategoryEnum.ANSWER.name() + " DQCategory.");
     }
+
+    @Test
+    public void testListDocumentsFromEmptyDict() {
+        CustomDictionaryHolder holder = CategoryRegistryManager.getInstance().getCustomDictionaryHolder();
+
+        DQCategory category = new DQCategory("EmptyCat");
+        category.setLabel("EmptyCat");
+        category.setName("EmptyCat");
+        category.setType(CategoryType.DICT);
+        category.setModified(true);
+        category.setCompleteness(false);
+
+        holder.createCategory(category);
+        List<DQDocument> docs = holder.getDictionaryCache().listDocuments("EmptyCat", 0, 100);
+        assertEquals(0, docs.size());
+    }
 }


### PR DESCRIPTION
…documents