### PR TITLE
Feat     TDQ-16372 Support minus sign and fractional numbers in

### DIFF
--- a/dataquality-text-japanese/src/main/java/org/talend/dataquality/jp/numbers/JapaneseNumberNormalizer.java
+++ b/dataquality-text-japanese/src/main/java/org/talend/dataquality/jp/numbers/JapaneseNumberNormalizer.java
@@ -18,6 +18,10 @@ import java.util.Locale;
 
 public class JapaneseNumberNormalizer {
 
+    private static final String negativeString = "マイナス";
+
+    private static final String negativeChar = "-";
+
     private static char NO_NUMERAL = Character.MAX_VALUE;
 
     private static char[] numerals;
@@ -103,9 +107,12 @@ public class JapaneseNumberNormalizer {
     private BigDecimal parseNumber(NumberBuffer buffer) {
         BigDecimal sum = BigDecimal.ZERO;
         boolean isNegative = false;
-        if (buffer.string.length() > 0 && isNegativeSign(buffer.charAt(0))) {
+        if (buffer.string.length() > 0 && isNegativeSign(buffer.string)) {
             isNegative = true;
-            buffer.advance();
+            int position = this.getNegativeStartIndex(buffer.string);
+            while (position-- > 0) {
+                buffer.advance();
+            }
         }
 
         // Remove prefix and suffix that are not numeric values
@@ -135,7 +142,7 @@ public class JapaneseNumberNormalizer {
 
     private boolean isNumeric(NumberBuffer buffer) {
         while (buffer.position < buffer.string.length()) {
-            if (!isNumeric(buffer.charAt(buffer.position))) {
+            if (!isNumeric(buffer, buffer.position)) {
                 return false;
             }
             buffer.advance();
@@ -146,16 +153,15 @@ public class JapaneseNumberNormalizer {
 
     private void computePrefix(NumberBuffer buffer) {
         int start = buffer.position;
-        while (buffer.position < buffer.string.length() && !isNumeric(buffer.charAt(buffer.position))) {
+        while (buffer.position < buffer.string.length() && !isNumeric(buffer, buffer.position)) {
             buffer.advance();
         }
-
         buffer.setPrefix(start, buffer.position);
     }
 
     private void computeSuffix(NumberBuffer buffer) {
         buffer.position = buffer.string.length();
-        while (buffer.position > 0 && !isNumeric(buffer.charAt(buffer.position - 1))) {
+        while (buffer.position > 0 && !isNumeric(buffer, buffer.position - 1)) {
             buffer.back();
         }
         buffer.setSuffix(buffer.position);
@@ -182,9 +188,10 @@ public class JapaneseNumberNormalizer {
         }
 
         if (first == null) {
-            // If there's no first factor, just return the second one,
-            // which is the same as multiplying by 1, i.e. with 万
-            return second;
+            // If there's no first factor, just return null,
+            // because the format is wrong. i.e. "万" TDQ-16372:
+            // "万 or bigger numbers needs 一 before it.  If they doesn't have 一 before it. they shouldn't be transferred."
+            return null;
         }
 
         return first.multiply(second);
@@ -420,6 +427,23 @@ public class JapaneseNumberNormalizer {
     }
 
     /**
+     * check if the numBuffer contain any char as decimal point
+     * 
+     * @param numBuffer
+     * @return true if buffer contains any char as decimal point
+     */
+    private boolean containDecimalPoint(NumberBuffer numBuffer) {
+        int i = numBuffer.position();
+        while (i < numBuffer.length()) {
+            char c = numBuffer.charAt(i);
+            if (isDecimalPoint(c)) {
+                return true;
+            }
+            i++;
+        }
+        return false;
+    }
+    /**
      * Thousand separator predicate
      *
      * @param c character to test
@@ -435,13 +459,29 @@ public class JapaneseNumberNormalizer {
         return exponents[c] != 0;
     }
 
-    private boolean isNegativeSign(char c) {
-        return c == '-' || c == '負';
+    private boolean isNegativeSign(String numberStr) {
+        if (numberStr.startsWith(negativeChar) && numberStr.lastIndexOf(negativeChar) == 0) {
+            return true;
+        } else if (numberStr.startsWith(negativeString) && numberStr.length() > negativeString.length()
+                && numberStr.lastIndexOf(negativeString) == 0) {
+            return true;
+        }
+        return false;
     }
 
-    private boolean isNumeric(char c) {
-        return isArabicNumeral(c) || isDecimalPoint(c) || isKanjiNumeral(c) || isKanjiExponent(c) || isNegativeSign(c)
-                || isThousandSeparator(c);
+    private int getNegativeStartIndex(String numberStr) {
+        if (numberStr.charAt(0) == '-') {
+            return 1;
+        } else if (numberStr.startsWith(negativeString)) {
+            return 4;
+        }
+        return -1;
+    }
+
+    private boolean isNumeric(NumberBuffer buffer, int position) {
+        char c = buffer.charAt(position);
+        return isArabicNumeral(c) || isDecimalPoint(c) || isKanjiNumeral(c) || isKanjiExponent(c)
+                || isNegativeSign(buffer.string) || isThousandSeparator(c);
     }
 
     /**
@@ -457,14 +497,23 @@ public class JapaneseNumberNormalizer {
         if (positionOfLine > -1) {
             // format the numerator
             NumberBuffer numeratorBuffer = new NumberBuffer(numberStr.substring(positionOfLine + 2, numberStr.length()));
+            if (containDecimalPoint(numeratorBuffer)) {// TDQ-16372 Decimal and fraction never used together
+                return numberNotTrimmed;
+            }
             BigDecimal numeratorNumber = this.parseNumber(numeratorBuffer);
+
             // format the denominator
             int start = 0;
-            if (isNegativeSign(numberStr.charAt(0))) {
-                start = 1;
-                numeratorNumber = numeratorNumber.negate();
+            if (isNegativeSign(numberStr)) {
+                start = getNegativeStartIndex(numberStr);
+                if (numeratorNumber != null) {
+                    numeratorNumber = numeratorNumber.negate();
+                }
             }
             NumberBuffer denominatorBuffer = new NumberBuffer(numberStr.substring(start, positionOfLine));
+            if (containDecimalPoint(denominatorBuffer)) {// TDQ-16372 Decimal and fraction never used together
+                return numberNotTrimmed;
+            }
             BigDecimal denominatorNumber = this.parseNumber(denominatorBuffer);
             if (numeratorNumber == null || denominatorNumber == null) {
                 return numberNotTrimmed;

--- a/dataquality-text-japanese/src/test/java/org/talend/dataquality/jp/numbers/JapaneseNumberNormalizerTest.java
+++ b/dataquality-text-japanese/src/test/java/org/talend/dataquality/jp/numbers/JapaneseNumberNormalizerTest.java
@@ -16,11 +16,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 public class JapaneseNumberNormalizerTest {
 
     private static Map<String, String> values = new HashMap<String, String>();
+
+    private static Map<String, String> minusValues = new HashMap<String, String>();
+
+    private static Map<String, String> fractionalValues = new HashMap<String, String>();
 
     static {
         values.put("", "");
@@ -29,17 +34,21 @@ public class JapaneseNumberNormalizerTest {
         values.put("〇〇七", "7");
         values.put("一〇〇〇", "1000");
         values.put("三千2百２十三", "3223");
-        values.put("-３．２千", "-3200");
         values.put("１．２万３４５．６７", "12345.67");
         values.put("１．２万３４５．６三", "12345.63");
         values.put("4,647.100", "4647.1");
         values.put("15,7", "157");
-        values.put("万", "10000");
+        values.put("万", "万");
         values.put("一万", "10000");
-        values.put("億", "100000000");
-        values.put("兆", "1000000000000");
-        values.put("京", "10000000000000000");
-        values.put("垓", "100000000000000000000");
+        values.put("六万", "60000");
+        values.put("億", "億");
+        values.put("一億", "100000000");
+        values.put("兆", "兆");
+        values.put("一兆", "1000000000000");
+        values.put("京", "京");
+        values.put("一京", "10000000000000000");
+        values.put("垓", "垓");
+        values.put("一垓", "100000000000000000000");
         values.put("九百八十三万 六千七百三", "9836703");
         values.put("二十億 三千六百五十二万 千八百一", "2036521801");
         values.put("abc二十億 三千六百五十二万 千八百一", "abc2036521801");
@@ -47,29 +56,88 @@ public class JapaneseNumberNormalizerTest {
         values.put("abc二十億 三千六百五十二万 千八百一def", "abc2036521801def");
         values.put("二十億 三千六百a五十二万 千八百一", "二十億 三千六百a五十二万 千八百一");
         values.put("七十五點四零二五", "75.4025");
-        values.put("負一千一百五十八", "-1158");
         values.put("百二十三円", "123円");
         values.put("¥百二十三", "¥123");
         values.put("五八五、四〇〇", "585,400");
         values.put("百五十七・五", "157.5");
-        values.put("二分の一", "1/2");
-        values.put("三分の二", "2/3");
-        values.put("百分の百七十", "170/100");
-        values.put("二分の", "二分の");
-        values.put("九百八十三万 六千七百三 分の 一千一百五十八", "1158/9836703");
-        values.put("分の二", "分の二");
-        values.put("二分七", "二分七");
-        values.put("負二分の一", "-1/2");
-        values.put("負分の一", "負分の一");
-        values.put("-３．２千分の一", "-1/3200");
+        values.put("百五十七点五", "157.5");
+        values.put("百五十七点〇", "157");
+
+        minusValues.put("-３．２千", "-3200");
+        minusValues.put("負一千一百五十八", "負1158");
+        minusValues.put("マイナス一千一百五十八", "-1158");
+        minusValues.put("マイナス二分の一", "-1/2");
+        minusValues.put("マイナス百五十八", "-158");
+        minusValues.put("マイナス三〇〇〇", "-3000");
+        minusValues.put("マイナス一万分の一", "-1/10000");
+        minusValues.put("マイナス一十分の一", "-1/10");
+        minusValues.put("マイナス十分の一", "-1/10");
+        minusValues.put("マイナス百分の一", "-1/100");
+        minusValues.put("マイナス一百分の一", "-1/100");
+        minusValues.put("マイナス千分の一", "-1/1000");
+        minusValues.put("マイナス一千分の一", "-1/1000");
+        minusValues.put("マイナス57マイナス", "マイナス57マイナス");
+        minusValues.put("マイナス万分の一", "マイナス万分の一");
+        minusValues.put("マイナス億分の一", "マイナス億分の一");
+        minusValues.put("マイナス兆分の一", "マイナス兆分の一");
+        minusValues.put("マイナス京分の一", "マイナス京分の一");
+        minusValues.put("-３．２千分の一", "-３．２千分の一");
+        minusValues.put("マイナス一億分の一", "-1/100000000");
+        minusValues.put("マイナス一兆分の一", "-1/1000000000000");
+        minusValues.put("マイナス一京分の一", "-1/10000000000000000");
+        minusValues.put("マイナス四万分の一", "-1/40000");
+        minusValues.put("マイナス七十万分の一", "-1/700000");
+
+        fractionalValues.put("二分の一", "1/2");
+        fractionalValues.put("三分の二", "2/3");
+        fractionalValues.put("百分の百七十", "170/100");
+        fractionalValues.put("二分の", "二分の");
+        fractionalValues.put("九百八十三万 六千七百三 分の 一千一百五十八", "1158/9836703");
+        fractionalValues.put("分の二", "分の二");
+        fractionalValues.put("二分七", "二分七");
+        fractionalValues.put("百分の百七十分の百", "百分の百七十分の百");
+        fractionalValues.put("十分の一", "1/10");
+        fractionalValues.put("百分の一", "1/100");
+        fractionalValues.put("千分の一", "1/1000");
+        fractionalValues.put("五千分の五", "5/5000");
+        fractionalValues.put("万分の一", "万分の一");
+        fractionalValues.put("一万分の一", "1/10000");
+        fractionalValues.put("八万分の一千", "1000/80000");
+        fractionalValues.put("億分の一", "億分の一");
+        fractionalValues.put("一億分の億", "一億分の億");
+        fractionalValues.put("一億分の一", "1/100000000");
+        fractionalValues.put("兆分の一", "兆分の一");
+        fractionalValues.put("一兆分の一", "1/1000000000000");
+        fractionalValues.put("百分の二百七十五点五", "百分の二百七十五点五");
+        fractionalValues.put("百分の二百七十五点〇", "百分の二百七十五点〇");
+    }
+
+    private JapaneseNumberNormalizer japaneseNumberFilter;
+
+    @Before
+    public void init() {
+        japaneseNumberFilter = new JapaneseNumberNormalizer();
     }
 
     @Test
     public void number() {
-
-        JapaneseNumberNormalizer japaneseNumberFilter = new JapaneseNumberNormalizer();
         for (String number : values.keySet()) {
             Assert.assertEquals(values.get(number), japaneseNumberFilter.normalizeNumber(number));
         }
     }
+
+    @Test
+    public void testMinusNumber() {
+        for (String number : minusValues.keySet()) {
+            Assert.assertEquals(minusValues.get(number), japaneseNumberFilter.normalizeNumber(number));
+        }
+    }
+
+    @Test
+    public void testFractionalNumber() {
+        for (String number : fractionalValues.keySet()) {
+            Assert.assertEquals(fractionalValues.get(number), japaneseNumberFilter.normalizeNumber(number));
+        }
+    }
+
 }


### PR DESCRIPTION
tJapaneseNumberNormalize
- support マイナス instead of 負
- upper than 万 should with number before it
- Fraction does not support decimal