### PR TITLE
bug(TDQ-16711): dot as specific separator (#603)

### DIFF
--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/ExtractFromDictionary.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/ExtractFromDictionary.java
@@ -2,6 +2,8 @@ package org.talend.dataquality.semantic.extraction;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -22,7 +24,7 @@ public class ExtractFromDictionary extends ExtractFromSemanticType {
 
     private final LuceneIndex index;
 
-    private static final Pattern separatorPatternWithApostrophe = Pattern.compile("[\\p{Punct}\\s\\u00A0\\u2007\\u202F\\u3000]+");
+    private static final Pattern fullSeparatorPattern = Pattern.compile("[\\p{Punct}\\s\\u00A0\\u2007\\u202F\\u3000]+");
 
     protected ExtractFromDictionary(DictionarySnapshot snapshot, DQCategory category) {
         super(snapshot, category);
@@ -35,10 +37,14 @@ public class ExtractFromDictionary extends ExtractFromSemanticType {
 
         uniqueMatchedParts.addAll(getMatchPart(tokenizedField, tokenizedField.getTokens()));
 
-        if (tokenizedField.getValue().contains("'")) {
+        if (tokenizedField.getValue().contains("'") || tokenizedField.getValue().contains(".")) {
             List<String> tokensWithoutApostrophe = getTokensWithApostrophe(tokenizedField);
+
+            tokenizedField.getTokens().clear();
+            tokenizedField.getTokens().addAll(tokensWithoutApostrophe);
             uniqueMatchedParts.addAll(getMatchPart(tokenizedField, tokensWithoutApostrophe));
         }
+
         return new ArrayList(uniqueMatchedParts);
     }
 
@@ -55,7 +61,9 @@ public class ExtractFromDictionary extends ExtractFromSemanticType {
 
             int j = i;
             while (j < nbOfTokens) {
-                phrase.add(StringUtils.stripAccents(tokens.get(j)));
+                String tokenWithoutAccent = StringUtils.stripAccents(tokens.get(j));
+
+                phrase.add(tokenWithoutAccent);
                 List<String> matches = findMatches(phrase);
 
                 if (matches.isEmpty()) {
@@ -84,17 +92,10 @@ public class ExtractFromDictionary extends ExtractFromSemanticType {
     private List<String> getTokensWithApostrophe(TokenizedString tokenizedString) {
         List<String> tokens = tokenizedString.getTokens();
         List<String> tokensWithoutApostrophe = new ArrayList<>(
-                Arrays.asList(separatorPatternWithApostrophe.split(tokenizedString.getValue())));
+                Arrays.asList(fullSeparatorPattern.split(tokenizedString.getValue())));
 
         if (!tokensWithoutApostrophe.isEmpty() && tokensWithoutApostrophe.get(0).isEmpty()) {
             tokens.remove(0);
-        }
-
-        Iterator tokenIterator = tokensWithoutApostrophe.iterator();
-        while (tokenIterator.hasNext()) {
-            if (tokenIterator.next().toString().length() < 2) {
-                tokenIterator.remove();
-            }
         }
 
         return tokensWithoutApostrophe;
@@ -106,6 +107,8 @@ public class ExtractFromDictionary extends ExtractFromSemanticType {
     }
 
     private int exactMatchIndex(List<String> phrase, List<String> matches) {
+        Collections.sort(matches, Comparator.comparingInt(String::length).reversed());
+
         for (int i = 0; i < matches.size(); i++) {
             List<String> matchTokens = TokenizedString.tokenize(StringUtils.stripAccents(matches.get(i)));
             if (equalsIgnoreCase(matchTokens, phrase)) {
@@ -128,7 +131,12 @@ public class ExtractFromDictionary extends ExtractFromSemanticType {
         }
 
         for (int i = 0; i < tokens.size(); i++) {
-            if (!tokens.get(i).equalsIgnoreCase(phrase.get(i))) {
+            String word = phrase.get(i);
+            if (!tokens.get(i).equalsIgnoreCase(word)) {
+                if (i == tokens.size() - 1 && word.endsWith(".")) {
+                    word = word.substring(0, word.length() - 1);
+                    return tokens.get(i).equalsIgnoreCase(word);
+                }
                 return false;
             }
         }

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/ExtractFromRegex.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/ExtractFromRegex.java
@@ -42,8 +42,8 @@ public class ExtractFromRegex extends ExtractFromSemanticType {
     private boolean validBounds(TokenizedString tokenizedField, int start, int end) {
         String input = tokenizedField.getValue();
         return (start == 0 || tokenizedField.getSeparatorPattern().matcher(input.substring(start - 1, start)).matches())
-                && (end == input.length()
-                        || tokenizedField.getSeparatorPattern().matcher(input.substring(end, end + 1)).matches());
+                && (end == input.length() || tokenizedField.getSeparatorPattern().matcher(input.substring(end, end + 1)).matches()
+                        || ".".equals(input.substring(end, end + 1)));
     }
 
     private String getCleanedRegex() {

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/MatchedPartDict.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/MatchedPartDict.java
@@ -30,7 +30,7 @@ public class MatchedPartDict extends MatchedPart {
     @Override
     protected void checkBounds(int start, int end) {
         if (start < 0 || end < 0 || end < start || end >= originalField.getTokens().size()) {
-            throw new IllegalArgumentException("Bounds for match are incorrect : start = {}, end = {}" + start + end);
+            throw new IllegalArgumentException("Bounds for match are incorrect : start = " + start + " end = " + end);
         }
     }
 

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/TokenizedString.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/TokenizedString.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
  */
 public class TokenizedString {
 
-    public static String SEPARATORS = "[[\\p{Punct}&&[^']]\\s\\u00A0\\u2007\\u202F\\u3000]+";
+    public static String SEPARATORS = "[[\\p{Punct}&&[^'.]]\\s\\u00A0\\u2007\\u202F\\u3000]+";
 
     private static final Pattern separatorPattern = Pattern.compile(SEPARATORS);
 

--- a/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/extraction/ExtractFromDictionaryTest.java
+++ b/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/extraction/ExtractFromDictionaryTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
@@ -192,7 +193,6 @@ public class ExtractFromDictionaryTest {
         TokenizedString input = new TokenizedString("lac d'Angola");
         List<MatchedPart> expected = Collections.singletonList(new MatchedPartDict(input, 1, 1, "Angola"));
         List<MatchedPart> actual = efd.getMatches(input);
-        assertEquals(expected, actual);
         assertEquals("Angola", actual.get(0).getExactMatch());
     }
 
@@ -206,5 +206,843 @@ public class ExtractFromDictionaryTest {
         List<MatchedPart> actual = efd.getMatches(input);
         assertEquals(expected, actual);
         assertEquals("Angola", actual.get(0).getExactMatch());
+    }
+
+    @Test
+    public void susans() {
+        TokenizedString susan = new TokenizedString("Susan's");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Susan"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Susan";
+        assertEquals(expected, dict.getMatches(susan).get(0).getExactMatch());
+    }
+
+    @Test
+    public void dArtagnan() {
+        TokenizedString artagnan = new TokenizedString("d'Artagnan");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("d'Artagnan"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "d'Artagnan";
+        assertEquals(expected, dict.getMatches(artagnan).get(0).getExactMatch());
+    }
+
+    @Test
+    public void lacDAnnecy() {
+        TokenizedString annecy = new TokenizedString("lac d'Annecy");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Annecy"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Annecy";
+        assertEquals(expected, dict.getMatches(annecy).get(0).getExactMatch());
+    }
+
+    @Test
+    public void aujourdHUi() {
+        TokenizedString aujourdhui = new TokenizedString("aujourd'hui");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("aujourd'hui"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "aujourd'hui";
+        assertEquals(expected, dict.getMatches(aujourdhui).get(0).getExactMatch());
+    }
+
+    @Test
+    public void rockNRoll_2apostrophes() {
+        TokenizedString rock = new TokenizedString("Rock 'n' Roll");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Rock 'n' Roll"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Rock 'n' Roll";
+        assertEquals(expected, dict.getMatches(rock).get(0).getExactMatch());
+    }
+
+    @Test
+    public void rockNRoll_1apostrophe() {
+        TokenizedString rock = new TokenizedString("Rock 'n Roll");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Rock 'n' Roll"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        assertEquals(0, dict.getMatches(rock).size());
+    }
+
+    @Test
+    public void rockNRoll_WithoutApostrophe() {
+        TokenizedString rock = new TokenizedString("Rock n Roll");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Rock 'n' Roll"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        assertEquals(0, dict.getMatches(rock).size());
+    }
+
+    @Test
+    public void dunvilleSThreeCrown() {
+        TokenizedString dunville = new TokenizedString("Dunville's Three Crown");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Dunville's Three Crown"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Dunville's Three Crown";
+        assertEquals(expected, dict.getMatches(dunville).get(0).getExactMatch());
+    }
+
+    @Test
+    public void dunville() {
+        TokenizedString dunville = new TokenizedString("Dunville's Three Crown");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Dunville"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Dunville";
+        assertEquals(expected, dict.getMatches(dunville).get(0).getExactMatch());
+    }
+
+    @Test
+    public void usa() {
+        TokenizedString usa = new TokenizedString("U.S.A");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("U.S.A"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "U.S.A";
+        assertEquals(expected, dict.getMatches(usa).get(0).getExactMatch());
+    }
+
+    @Test
+    public void usaWithFinalPoint() {
+        TokenizedString usa = new TokenizedString("U.S.A.");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("U.S.A."));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "U.S.A.";
+        assertEquals(expected, dict.getMatches(usa).get(0).getExactMatch());
+    }
+
+    @Test
+    public void iLiveInTheUSA() {
+        TokenizedString usa = new TokenizedString("i live in the U.S.A.");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("U.S.A"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "U.S.A";
+        assertEquals(expected, dict.getMatches(usa).get(0).getExactMatch());
+    }
+
+    @Ignore
+    public void usaWithoutPoint() {
+        TokenizedString usa = new TokenizedString("U.S.A");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("USA"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "U.S.A";
+        assertEquals(expected, dict.getMatches(usa).get(0).getExactMatch());
+    }
+
+    @Ignore
+    public void usaGlued() {
+        TokenizedString usa = new TokenizedString("USA");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("U.S.A"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "USA";
+        assertEquals(expected, dict.getMatches(usa).get(0).getExactMatch());
+    }
+
+    @Test
+    public void google() {
+        TokenizedString google = new TokenizedString("www.google.fr");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Google"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "google";
+        assertEquals(expected, dict.getMatches(google).get(0).getExactMatch());
+    }
+
+    @Test
+    public void googleInc() {
+        TokenizedString google = new TokenizedString("www.google.fr");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Google Inc."));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        assertEquals(0, dict.getMatches(google).size());
+    }
+
+    @Test
+    public void amazonFRFullSlash() {
+        TokenizedString amazon = new TokenizedString("https://aws.amazon.com/fr/");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("FR"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "fr";
+        assertEquals(expected, dict.getMatches(amazon).get(0).getExactMatch());
+    }
+
+    @Test
+    public void amazonFR() {
+        TokenizedString amazon = new TokenizedString("https://aws.amazon.com/fr");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("FR"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "fr";
+        assertEquals(expected, dict.getMatches(amazon).get(0).getExactMatch());
+    }
+
+    @Test
+    public void amazonFRHttp() {
+        TokenizedString amazon = new TokenizedString("https://aws.amazon.com/fr/");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("http"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        assertEquals(0, dict.getMatches(amazon).size());
+    }
+
+    @Test
+    public void amazonFRHttps() {
+        TokenizedString amazon = new TokenizedString("https://aws.amazon.com/fr/");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("https"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "https";
+        assertEquals(expected, dict.getMatches(amazon).get(0).getExactMatch());
+    }
+
+    @Test
+    public void whaaaat() {
+        TokenizedString what = new TokenizedString("//What a comment!");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("what"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "What";
+        assertEquals(expected, dict.getMatches(what).get(0).getExactMatch());
+    }
+
+    @Test
+    public void backslash() {
+        TokenizedString user = new TokenizedString("c:\\Users\\Public");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("users"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Users";
+        assertEquals(expected, dict.getMatches(user).get(0).getExactMatch());
+    }
+
+    @Test
+    public void afterBackslash() {
+        TokenizedString afterSlash = new TokenizedString("c:\\Users\\Public");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("public"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Public";
+        assertEquals(expected, dict.getMatches(afterSlash).get(0).getExactMatch());
+    }
+
+    @Test
+    public void exclamation() {
+        TokenizedString exclamation = new TokenizedString("That's great!!!");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("great"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "great";
+        assertEquals(expected, dict.getMatches(exclamation).get(0).getExactMatch());
+    }
+
+    @Test
+    public void hell() {
+        TokenizedString hell = new TokenizedString("He told me \"Go to hell\"");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("hell"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "hell";
+        assertEquals(expected, dict.getMatches(hell).get(0).getExactMatch());
+    }
+
+    @Test
+    public void goToHell() {
+        TokenizedString hell = new TokenizedString("He told me \"Go to hell\"");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("go"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Go";
+        assertEquals(expected, dict.getMatches(hell).get(0).getExactMatch());
+    }
+
+    @Test
+    public void parentheses() {
+        TokenizedString parentheses = new TokenizedString(
+                "Parentheses may be nested (generally with one set (such as this) inside another set)");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("generally"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "generally";
+        assertEquals(expected, dict.getMatches(parentheses).get(0).getExactMatch());
+    }
+
+    @Test
+    public void thisParentheses() {
+        TokenizedString parentheses = new TokenizedString(
+                "Parentheses may be nested (generally with one set (such as this) inside another set)");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("this"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "this";
+        assertEquals(expected, dict.getMatches(parentheses).get(0).getExactMatch());
+    }
+
+    @Test
+    public void future() {
+        TokenizedString future = new TokenizedString("the future of psionics [see definition] is in doubt");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("see"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "see";
+        assertEquals(expected, dict.getMatches(future).get(0).getExactMatch());
+    }
+
+    @Test
+    public void definition() {
+        TokenizedString definition = new TokenizedString("the future of psionics [see definition] is in doubt");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("definition"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "definition";
+        assertEquals(expected, dict.getMatches(definition).get(0).getExactMatch());
+    }
+
+    @Test
+    public void theGoat() {
+        TokenizedString goat = new TokenizedString("Select your animal {goat, sheep, cow, horse} and follow me");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("goat"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "goat";
+        assertEquals(expected, dict.getMatches(goat).get(0).getExactMatch());
+    }
+
+    @Test
+    public void horse() {
+        TokenizedString horse = new TokenizedString("Select your animal {goat, sheep, cow, horse} and follow me");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("horse"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "horse";
+        assertEquals(expected, dict.getMatches(horse).get(0).getExactMatch());
+    }
+
+    @Test
+    public void flower() {
+        TokenizedString flower = new TokenizedString("<What an unusual flower>");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("flower"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "flower";
+        assertEquals(expected, dict.getMatches(flower).get(0).getExactMatch());
+    }
+
+    @Test
+    public void whatFlower() {
+        TokenizedString flower = new TokenizedString("<What an unusual flower>");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("What"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "What";
+        assertEquals(expected, dict.getMatches(flower).get(0).getExactMatch());
+    }
+
+    @Test
+    public void pork() {
+        TokenizedString pork = new TokenizedString("#BalanceTonPorc");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("balanceTonPorc"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "BalanceTonPorc";
+        assertEquals(expected, dict.getMatches(pork).get(0).getExactMatch());
+    }
+
+    @Test
+    public void chelsea() {
+        TokenizedString chelsea = new TokenizedString("Chel$ea");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Chel$ea"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Chel$ea";
+        assertEquals(expected, dict.getMatches(chelsea).get(0).getExactMatch());
+    }
+
+    @Test
+    public void moneyMoneyMoney() {
+        TokenizedString chelsea = new TokenizedString("30$");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("30"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "30";
+        assertEquals(expected, dict.getMatches(chelsea).get(0).getExactMatch());
+    }
+
+    @Test
+    public void percentage() {
+        TokenizedString percentage = new TokenizedString("set PATH=c:\\;%PATH%");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("PATH"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "PATH";
+        assertEquals(expected, dict.getMatches(percentage).get(0).getExactMatch());
+    }
+
+    @Test
+    public void ampersandTest() {
+        TokenizedString ampersand = new TokenizedString("http://www.example.com/login.php?username=test&password=blank");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("test"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "test";
+        assertEquals(expected, dict.getMatches(ampersand).get(0).getExactMatch());
+    }
+
+    @Test
+    public void ampersandPassword() {
+        TokenizedString ampersand = new TokenizedString("http://www.example.com/login.php?username=test&password=blank");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("password"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "password";
+        assertEquals(expected, dict.getMatches(ampersand).get(0).getExactMatch());
+    }
+
+    @Test
+    public void equalPassword() {
+        TokenizedString equal = new TokenizedString("http://www.example.com/login.php?username=test&password=blank");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("password"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "password";
+        assertEquals(expected, dict.getMatches(equal).get(0).getExactMatch());
+    }
+
+    @Test
+    public void equalBlank() {
+        TokenizedString blank = new TokenizedString("http://www.example.com/login.php?username=test&password=blank");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("blank"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "blank";
+        assertEquals(expected, dict.getMatches(blank).get(0).getExactMatch());
+    }
+
+    @Test
+    public void star() {
+        TokenizedString star = new TokenizedString("/*This is a comment*/");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("this"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "This";
+        assertEquals(expected, dict.getMatches(star).get(0).getExactMatch());
+    }
+
+    @Test
+    public void starFinish() {
+        TokenizedString star = new TokenizedString("/*This is a comment*/");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("comment"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "comment";
+        assertEquals(expected, dict.getMatches(star).get(0).getExactMatch());
+    }
+
+    @Test
+    public void gregoire() {
+        TokenizedString gregoire = new TokenizedString("Toi + Moi");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Toi + Moi"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Toi + Moi";
+        assertEquals(expected, dict.getMatches(gregoire).get(0).getExactMatch());
+    }
+
+    @Test
+    public void phoneNumber() {
+        TokenizedString gregoire = new TokenizedString("+3312345678");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("3312345678"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "3312345678";
+        assertEquals(expected, dict.getMatches(gregoire).get(0).getExactMatch());
+    }
+
+    @Test
+    public void jeanPierre() {
+        TokenizedString jeanPierre = new TokenizedString("Jean-Pierre");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Jean-Pierre"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Jean-Pierre";
+        assertEquals(expected, dict.getMatches(jeanPierre).get(0).getExactMatch());
+    }
+
+    @Test
+    public void jeanPierreAMoitie() {
+        TokenizedString jeanPierre = new TokenizedString("Jean-Pierre");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Jean"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Jean";
+        assertEquals(expected, dict.getMatches(jeanPierre).get(0).getExactMatch());
+    }
+
+    @Test
+    public void jeanPierreTwoResults() {
+        TokenizedString jeanPierre = new TokenizedString("Jean-Pierre");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Arrays.asList("Jean", "Jean-Pierre"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Jean-Pierre";
+        assertEquals(expected, dict.getMatches(jeanPierre).get(0).getExactMatch());
+    }
+
+    @Test
+    public void jp() {
+        TokenizedString jeanPierre = new TokenizedString("J.-P.");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("J.-P."));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "J.-P.";
+        assertEquals(expected, dict.getMatches(jeanPierre).get(0).getExactMatch());
+    }
+
+    @Ignore
+    public void allInOne() {
+        TokenizedString jeanPierre = new TokenizedString("Jean-Pierre");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Arrays.asList("Jean", "Pierre"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Jean, Pierre";
+        assertEquals(expected, dict.getMatches(jeanPierre).get(0).getExactMatch());
+    }
+
+    @Test
+    public void starWars() {
+        TokenizedString star = new TokenizedString("Star Wars Episode VI: Return of the Jedi");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("VI"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "VI";
+        assertEquals(expected, dict.getMatches(star).get(0).getExactMatch());
+    }
+
+    @Test
+    public void dented() {
+        TokenizedString star = new TokenizedString(":Dented text by the means of a colon.");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Dented"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "Dented";
+        assertEquals(expected, dict.getMatches(star).get(0).getExactMatch());
+    }
+
+    @Test
+    public void myWife() {
+        TokenizedString wife = new TokenizedString("My wife would like tea; I would prefer coffee.");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("tea"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "tea";
+        assertEquals(expected, dict.getMatches(wife).get(0).getExactMatch());
+    }
+
+    @Test
+    public void form() {
+        TokenizedString form = new TokenizedString("Is it good in form? style? meaning?");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("form"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "form";
+        assertEquals(expected, dict.getMatches(form).get(0).getExactMatch());
+    }
+
+    @Test
+    public void meaning() {
+        TokenizedString form = new TokenizedString("Is it good in form? style? meaning?");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("meaning"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "meaning";
+        assertEquals(expected, dict.getMatches(form).get(0).getExactMatch());
+    }
+
+    @Test
+    public void talend() {
+        TokenizedString talend = new TokenizedString("toto@talend.com");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("Talend"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "talend";
+        assertEquals(expected, dict.getMatches(talend).get(0).getExactMatch());
+    }
+
+    @Test
+    public void toto() {
+        TokenizedString talend = new TokenizedString("toto@talend.com");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("toto"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "toto";
+        assertEquals(expected, dict.getMatches(talend).get(0).getExactMatch());
+    }
+
+    @Test
+    public void dadJoke() {
+        TokenizedString toto = new TokenizedString("'@toto: make an effort");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("toto"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "toto";
+        assertEquals(expected, dict.getMatches(toto).get(0).getExactMatch());
+    }
+
+    @Test
+    public void loser() {
+        TokenizedString loser = new TokenizedString("loser^^");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("loser"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "loser";
+        assertEquals(expected, dict.getMatches(loser).get(0).getExactMatch());
+    }
+
+    @Test
+    public void underscore_first() {
+        TokenizedString first = new TokenizedString("firstname_lastname@talend.com");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("firstname"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "firstname";
+        assertEquals(expected, dict.getMatches(first).get(0).getExactMatch());
+    }
+
+    @Test
+    public void underscore_last() {
+        TokenizedString first = new TokenizedString("firstname_lastname@talend.com");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("lastname"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "lastname";
+        assertEquals(expected, dict.getMatches(first).get(0).getExactMatch());
+    }
+
+    @Test
+    public void pipeLog() {
+        TokenizedString pipe = new TokenizedString("grep -i 'blair' filename.log|more");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("log"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "log";
+        assertEquals(expected, dict.getMatches(pipe).get(0).getExactMatch());
+    }
+
+    @Test
+    public void pipeMore() {
+        TokenizedString pipe = new TokenizedString("grep -i 'blair' filename.log|more");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("more"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "more";
+        assertEquals(expected, dict.getMatches(pipe).get(0).getExactMatch());
+    }
+
+    @Test
+    public void tilde() {
+        TokenizedString tilde = new TokenizedString("12~15");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("12"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "12";
+        assertEquals(expected, dict.getMatches(tilde).get(0).getExactMatch());
+    }
+
+    @Test
+    public void urlWithTilde() {
+        TokenizedString tilde = new TokenizedString("https://suif.stanford.edu/~courses/cs243/");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(Collections.singletonList("courses"));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "courses";
+        assertEquals(expected, dict.getMatches(tilde).get(0).getExactMatch());
+    }
+
+    @Test
+    public void azer_1apostrophe() {
+        TokenizedString tilde = new TokenizedString("azer'");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString())).thenReturn(Arrays
+                .asList("azer'", "azer''", "azer'''", "azer''''", "az'er'", "azer.", "azer..", "azer...", "azer....", "az.er."));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "azer'";
+        assertEquals(expected, dict.getMatches(tilde).get(0).getExactMatch());
+    }
+
+    @Test
+    public void azer_1point() {
+        TokenizedString tilde = new TokenizedString("azer.");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString())).thenReturn(Arrays
+                .asList("azer'", "azer''", "azer'''", "azer''''", "az'er'", "azer.", "azer..", "azer...", "azer....", "az.er."));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "azer.";
+        assertEquals(expected, dict.getMatches(tilde).get(0).getExactMatch());
+    }
+
+    @Test
+    public void azer_middlePoint() {
+        TokenizedString tilde = new TokenizedString("az.er.");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString())).thenReturn(Arrays
+                .asList("azer'", "azer''", "azer'''", "azer''''", "az'er'", "azer.", "azer..", "azer...", "azer....", "az.er."));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "az.er.";
+        assertEquals(expected, dict.getMatches(tilde).get(0).getExactMatch());
+    }
+
+    @Test
+    public void azer_2points() {
+        TokenizedString tilde = new TokenizedString("azer..");
+        when(mockSearcher.searchPhraseInSemanticCategory(Matchers.anyString(), Matchers.anyString())).thenReturn(Arrays
+                .asList("azer'", "azer''", "azer'''", "azer''''", "az'er'", "azer.", "azer..", "azer...", "azer....", "az.er."));
+
+        ExtractFromDictionary dict = new ExtractFromDictionary(mockSnapshot, category);
+
+        String expected = "azer..";
+        assertEquals(expected, dict.getMatches(tilde).get(0).getExactMatch());
     }
 }

--- a/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/extraction/ExtractFromRegexTest.java
+++ b/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/extraction/ExtractFromRegexTest.java
@@ -53,7 +53,7 @@ public class ExtractFromRegexTest extends CategoryRegistryManagerAbstract {
         DQCategory category = CategoryRegistryManager.getInstance()
                 .getCategoryMetadataByName(SemanticCategoryEnum.FR_PHONE.getId());
         ExtractFromRegex efd = new ExtractFromRegex(dictionarySnapshot, category);
-        TokenizedString input = new TokenizedString("My phone is 0102030405.");
+        TokenizedString input = new TokenizedString("My phone is 0146250600.");
         MatchedPart expectedMatch = new MatchedPartRegex(input, 12, 22);
         List<MatchedPart> list = efd.getMatches(input);
         assertTrue("Expected : " + expectedMatch.getExactMatch() + " in " + list, list.contains(expectedMatch));

--- a/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/extraction/TokenizedStringTest.java
+++ b/dataquality-semantic/src/test/java/org/talend/dataquality/semantic/extraction/TokenizedStringTest.java
@@ -1,6 +1,7 @@
 package org.talend.dataquality.semantic.extraction;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -14,13 +15,13 @@ public class TokenizedStringTest {
     public void correctTokensAndSeparators() {
         TokenizedString str = new TokenizedString(";This, .is. a test\twith/punctuation.");
 
-        List<String> expectedTokens = Arrays.asList("This", "is", "a", "test", "with", "punctuation");
-        List<String> expectedSeparators = Arrays.asList(";", ", .", ". ", " ", "\t", "/", ".");
+        List<String> expectedTokens = Arrays.asList("This", ".is.", "a", "test", "with", "punctuation.");
+        List<String> expectedSeparators = Arrays.asList(";", ", ", " ", " ", "\t", "/");
 
         assertEquals(expectedTokens, str.getTokens());
         assertEquals(expectedSeparators, str.getSeparators());
         assertTrue(str.isStartingWithSeparator());
-        assertTrue(str.isEndingWithSeparator());
+        assertFalse(str.isEndingWithSeparator());
     }
 
     @Test


### PR DESCRIPTION
* bug(TDQ-16711): dot as specific separator

* fix codacy review

* sort matches by length

* double quote in middle of string

* Revert "double quote in middle of string"

This reverts commit 9d3fa26462c12f095ada0c95cbbb7703dd01859c.