### PR TITLE
bug(TDQ-16711) : clone instead of reuse for value extraction (#617)

### DIFF
--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/ExtractFromDictionary.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/ExtractFromDictionary.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -38,11 +37,13 @@ public class ExtractFromDictionary extends ExtractFromSemanticType {
         uniqueMatchedParts.addAll(getMatchPart(tokenizedField, tokenizedField.getTokens()));
 
         if (tokenizedField.getValue().contains("'") || tokenizedField.getValue().contains(".")) {
-            List<String> tokensWithoutApostrophe = getTokensWithApostrophe(tokenizedField);
+            TokenizedString clone = new TokenizedString(tokenizedField.getValue());
 
-            tokenizedField.getTokens().clear();
-            tokenizedField.getTokens().addAll(tokensWithoutApostrophe);
-            uniqueMatchedParts.addAll(getMatchPart(tokenizedField, tokensWithoutApostrophe));
+            List<String> tokensWithoutApostrophe = getTokensWithoutApostropheAndDots(tokenizedField);
+
+            clone.getTokens().clear();
+            clone.getTokens().addAll(tokensWithoutApostrophe);
+            uniqueMatchedParts.addAll(getMatchPart(clone, tokensWithoutApostrophe));
         }
 
         return new ArrayList(uniqueMatchedParts);
@@ -89,7 +90,7 @@ public class ExtractFromDictionary extends ExtractFromSemanticType {
         return matchedParts;
     }
 
-    private List<String> getTokensWithApostrophe(TokenizedString tokenizedString) {
+    private List<String> getTokensWithoutApostropheAndDots(TokenizedString tokenizedString) {
         List<String> tokens = tokenizedString.getTokens();
         List<String> tokensWithoutApostrophe = new ArrayList<>(
                 Arrays.asList(fullSeparatorPattern.split(tokenizedString.getValue())));

--- a/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/MatchedPart.java
+++ b/dataquality-semantic/src/main/java/org/talend/dataquality/semantic/extraction/MatchedPart.java
@@ -114,7 +114,10 @@ public abstract class MatchedPart implements Comparable<MatchedPart> {
         }
 
         MatchedPart otherMatchedPart = (MatchedPart) o;
-        return originalField.toString().equals(otherMatchedPart.originalField.toString())
+        return originalField.getValue().equals(otherMatchedPart.originalField.getValue())
+                && originalField.getSeparators().equals(otherMatchedPart.originalField.getSeparators())
+                && originalField.isStartingWithSeparator() == otherMatchedPart.originalField.isStartingWithSeparator()
+                && originalField.isEndingWithSeparator() == otherMatchedPart.originalField.isEndingWithSeparator()
                 && tokenPositions.equals(otherMatchedPart.tokenPositions) && exactMatch.equals(otherMatchedPart.exactMatch);
     }
 }


### PR DESCRIPTION
* bug(TDQ-16711) : clone instead of reuse

* modify equality

* renaming function