### PR TITLE
chore(TDS-764): adding getter to the statistics map

### DIFF
--- a/dataquality-statistics/CHANGELOG.md
+++ b/dataquality-statistics/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - chore(TDQ-17710): Adopt the "Keep a Changelog" format for changelogs
 ### Changed
-N/A
+- chore(TDS-764): adding methods for paginated frequencies
 ### Removed
 N/A
 ### Deprecated

--- a/dataquality-statistics/CHANGELOG.md
+++ b/dataquality-statistics/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - chore(TDQ-17710): Adopt the "Keep a Changelog" format for changelogs
 ### Changed
-- chore(TDS-764): adding methods for paginated frequencies
+- chore(TDS-764): adding getter to retrieve statistics map
 ### Removed
 N/A
 ### Deprecated

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/frequency/AbstractFrequencyStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/frequency/AbstractFrequencyStatistics.java
@@ -35,20 +35,8 @@ public abstract class AbstractFrequencyStatistics {
         value2freq.put(value, freq + 1);
     }
 
-    public Map<String, Long> getAll() {
-        return value2freq.entrySet().stream().sorted(Map.Entry.<String, Long> comparingByValue().reversed())
-                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue(), (v1, v2) -> v2, LinkedHashMap::new));
-    }
-
-    public Map<String, Long> getPage(int page, int pageSize) {
-        int startIndex = page * pageSize;
-        return value2freq.entrySet().stream().sorted(Map.Entry.<String, Long> comparingByValue().reversed()).skip(startIndex)
-                .limit(pageSize)
-                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue(), (v1, v2) -> v2, LinkedHashMap::new));
-    }
-
-    public int getTotal() {
-        return value2freq.entrySet().size();
+    public Map<String, Long> getValue2freq() {
+        return value2freq;
     }
 
     public Map<String, Long> getTopK(int topk) {

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/frequency/AbstractFrequencyStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/frequency/AbstractFrequencyStatistics.java
@@ -42,6 +42,10 @@ public abstract class AbstractFrequencyStatistics {
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue(), (v1, v2) -> v2, LinkedHashMap::new));
     }
 
+    public int getTotal() {
+        return value2freq.entrySet().size();
+    }
+
     public Map<String, Long> getTopK(int topk) {
         return value2freq.entrySet().stream().sorted(Map.Entry.<String, Long> comparingByValue().reversed()).limit(topk)
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue(), (v1, v2) -> v2, LinkedHashMap::new));

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/frequency/AbstractFrequencyStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/frequency/AbstractFrequencyStatistics.java
@@ -35,6 +35,11 @@ public abstract class AbstractFrequencyStatistics {
         value2freq.put(value, freq + 1);
     }
 
+    public Map<String, Long> getAll() {
+        return value2freq.entrySet().stream().sorted(Map.Entry.<String, Long> comparingByValue().reversed())
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue(), (v1, v2) -> v2, LinkedHashMap::new));
+    }
+
     public Map<String, Long> getPage(int page, int pageSize) {
         int startIndex = page * pageSize;
         return value2freq.entrySet().stream().sorted(Map.Entry.<String, Long> comparingByValue().reversed()).skip(startIndex)

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/frequency/AbstractFrequencyStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/frequency/AbstractFrequencyStatistics.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 
 /**
  * Frequency statistics bean which delegate the computation to evaluator.
- * 
+ *
  * @author mzhao
  *
  */
@@ -37,8 +37,8 @@ public abstract class AbstractFrequencyStatistics {
 
     public Map<String, Long> getPage(int page, int pageSize) {
         int startIndex = page * pageSize;
-        return value2freq.entrySet().stream().sorted(Map.Entry.<String, Long> comparingByValue().reversed())
-                .skip(startIndex).limit(pageSize)
+        return value2freq.entrySet().stream().sorted(Map.Entry.<String, Long> comparingByValue().reversed()).skip(startIndex)
+                .limit(pageSize)
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue(), (v1, v2) -> v2, LinkedHashMap::new));
     }
 

--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/frequency/AbstractFrequencyStatistics.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/frequency/AbstractFrequencyStatistics.java
@@ -35,6 +35,13 @@ public abstract class AbstractFrequencyStatistics {
         value2freq.put(value, freq + 1);
     }
 
+    public Map<String, Long> getPage(int page, int pageSize) {
+        int startIndex = page * pageSize;
+        return value2freq.entrySet().stream().sorted(Map.Entry.<String, Long> comparingByValue().reversed())
+                .skip(startIndex).limit(pageSize)
+                .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue(), (v1, v2) -> v2, LinkedHashMap::new));
+    }
+
     public Map<String, Long> getTopK(int topk) {
         return value2freq.entrySet().stream().sorted(Map.Entry.<String, Long> comparingByValue().reversed()).limit(topk)
                 .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue(), (v1, v2) -> v2, LinkedHashMap::new));

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/StatisticsFrequencyTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/StatisticsFrequencyTest.java
@@ -33,33 +33,6 @@ public class StatisticsFrequencyTest {
     }
 
     @Test
-    public void testGetPage() {
-        // when
-        Map<String, Long> page0 = stats.getPage(0, 2);
-        Map<String, Long> page2 = stats.getPage(2, 2);
-
-        // expect
-        Assert.assertEquals(2, page0.keySet().size());
-        Assert.assertEquals(Long.valueOf(10), page0.get("10"));
-        Assert.assertEquals(Long.valueOf(9), page0.get("9"));
-        // page 1 should be 8 and 7
-        Assert.assertEquals(2, page2.keySet().size());
-        Assert.assertEquals(Long.valueOf(6), page2.get("6"));
-        Assert.assertEquals(Long.valueOf(5), page2.get("5"));
-
-        // another page and size
-        Map<String, Long> page3 = stats.getPage(3, 3);
-        Assert.assertEquals(1, page3.keySet().size());
-        Assert.assertEquals(Long.valueOf(1), page3.get("1"));
-    }
-
-    @Test
-    public void testGetTotal() {
-        // expect
-        Assert.assertEquals(10, stats.getTotal());
-    }
-
-    @Test
     public void getTopK() {
         // when
         Map<String, Long> results = stats.getTopK(3);
@@ -69,14 +42,5 @@ public class StatisticsFrequencyTest {
         Assert.assertEquals(Long.valueOf(10), results.get("10"));
         Assert.assertEquals(Long.valueOf(9), results.get("9"));
         Assert.assertEquals(Long.valueOf(8), results.get("8"));
-    }
-
-    @Test
-    public void getAll() {
-        // when
-        Map<String, Long> results = stats.getAll();
-
-        // expect
-        Assert.assertEquals(10, results.keySet().size());
     }
 }

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/StatisticsFrequencyTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/StatisticsFrequencyTest.java
@@ -25,7 +25,7 @@ public class StatisticsFrequencyTest {
     @Before
     public void setUp() throws Exception {
         stats = new DataTypeFrequencyStatistics();
-        for (int i = 1; i <= 10 ; i++) {
+        for (int i = 1; i <= 10; i++) {
             for (int j = 0; j < i; j++) {
                 stats.add(Integer.toString(i));
             }

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/StatisticsFrequencyTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/StatisticsFrequencyTest.java
@@ -34,8 +34,11 @@ public class StatisticsFrequencyTest {
 
     @Test
     public void testGetPage() {
+        // when
         Map<String, Long> page0 = stats.getPage(0, 2);
         Map<String, Long> page2 = stats.getPage(2, 2);
+
+        // expect
         Assert.assertEquals(2, page0.keySet().size());
         Assert.assertEquals(Long.valueOf(10), page0.get("10"));
         Assert.assertEquals(Long.valueOf(9), page0.get("9"));
@@ -51,8 +54,17 @@ public class StatisticsFrequencyTest {
     }
 
     @Test
+    public void testGetTotal() {
+        // expect
+        Assert.assertEquals(10, stats.getTotal());
+    }
+
+    @Test
     public void getTopK() {
+        // when
         Map<String, Long> results = stats.getTopK(3);
+
+        // expect
         Assert.assertEquals(3, results.keySet().size());
         Assert.assertEquals(Long.valueOf(10), results.get("10"));
         Assert.assertEquals(Long.valueOf(9), results.get("9"));

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/StatisticsFrequencyTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/StatisticsFrequencyTest.java
@@ -71,4 +71,12 @@ public class StatisticsFrequencyTest {
         Assert.assertEquals(Long.valueOf(8), results.get("8"));
     }
 
+    @Test
+    public void getAll() {
+        // when
+        Map<String, Long> results = stats.getAll();
+
+        // expect
+        Assert.assertEquals(10, results.keySet().size());
+    }
 }

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/StatisticsFrequencyTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/frequency/StatisticsFrequencyTest.java
@@ -1,0 +1,62 @@
+// ============================================================================
+//
+// Copyright (C) 2006-2016 Talend Inc. - www.talend.com
+//
+// This source code is available under agreement available at
+// %InstallDIR%\features\org.talend.rcp.branding.%PRODUCTNAME%\%PRODUCTNAME%license.txt
+//
+// You should have received a copy of the agreement
+// along with this program; if not, write to Talend SA
+// 9 rue Pages 92150 Suresnes, France
+//
+// ============================================================================
+package org.talend.dataquality.statistics.frequency;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Map;
+
+public class StatisticsFrequencyTest {
+
+    private DataTypeFrequencyStatistics stats;
+
+    @Before
+    public void setUp() throws Exception {
+        stats = new DataTypeFrequencyStatistics();
+        for (int i = 1; i <= 10 ; i++) {
+            for (int j = 0; j < i; j++) {
+                stats.add(Integer.toString(i));
+            }
+        }
+    }
+
+    @Test
+    public void testGetPage() {
+        Map<String, Long> page0 = stats.getPage(0, 2);
+        Map<String, Long> page2 = stats.getPage(2, 2);
+        Assert.assertEquals(2, page0.keySet().size());
+        Assert.assertEquals(Long.valueOf(10), page0.get("10"));
+        Assert.assertEquals(Long.valueOf(9), page0.get("9"));
+        // page 1 should be 8 and 7
+        Assert.assertEquals(2, page2.keySet().size());
+        Assert.assertEquals(Long.valueOf(6), page2.get("6"));
+        Assert.assertEquals(Long.valueOf(5), page2.get("5"));
+
+        // another page and size
+        Map<String, Long> page3 = stats.getPage(3, 3);
+        Assert.assertEquals(1, page3.keySet().size());
+        Assert.assertEquals(Long.valueOf(1), page3.get("1"));
+    }
+
+    @Test
+    public void getTopK() {
+        Map<String, Long> results = stats.getTopK(3);
+        Assert.assertEquals(3, results.keySet().size());
+        Assert.assertEquals(Long.valueOf(10), results.get("10"));
+        Assert.assertEquals(Long.valueOf(9), results.get("9"));
+        Assert.assertEquals(Long.valueOf(8), results.get("8"));
+    }
+
+}


### PR DESCRIPTION
## Developer

**Link to the JIRA issue**
- https://jira.talendforge.org/browse/TDS-764

**What is the problem this Pull Request is trying to solve?**
In order to have paginated result for data frequencies we can't use the getTopK method anymore 

**What is the chosen solution to this problem?**
  Adding a getter to retrieve the data in order to do whatever we want with it
 
**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

## Reviewer

**Please check if the Pull Request fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] (if needed) Docs have been added / updated
- [ ] Changelog has been updated
