### PR TITLE
Chore(TDQ-17834): Send slack message only for master and maintenance …

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -58,6 +58,7 @@ pipeline {
             steps {
                 container('talend-jdk8-builder-base') {
                     configFileProvider([configFile(fileId: 'maven-settings-nexus-zl', variable: 'MAVEN_SETTINGS')]) {
+                        sh 'java -version'
                         sh 'mvn --version'
                         sh 'mvn clean test -B --fail-at-end -s $MAVEN_SETTINGS'
                     }
@@ -87,7 +88,6 @@ pipeline {
         }
     }
 
-
     post {
         success {
             script {
@@ -97,16 +97,27 @@ pipeline {
             }
         }
         failure {
-            slackSend(color: '#e96065', channel: "${SLACK_CHANNEL}", message: "FAILED: `${env.JOB_NAME.replaceAll('%2F', '/')}` #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+            script {
+                if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME =~ 'maintenance.*') {
+                    slackSend(color: '#e96065', channel: "${SLACK_CHANNEL}", message: "FAILED: `${env.JOB_NAME.replaceAll('%2F', '/')}` #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+                }
+            }
         }
 
         unstable {
-            slackSend(color: '#ea8330', channel: "${SLACK_CHANNEL}", message: "UNSTABLE: `${env.JOB_NAME.replaceAll('%2F', '/')}` #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+            script {
+                if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME =~ 'maintenance.*') {
+                    slackSend(color: '#ea8330', channel: "${SLACK_CHANNEL}", message: "UNSTABLE: `${env.JOB_NAME.replaceAll('%2F', '/')}` #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+                }
+            }
         }
 
         aborted {
-            slackSend(color: '#c6c6c6', channel: "${SLACK_CHANNEL}", message: "ABORTED: `${env.JOB_NAME.replaceAll('%2F', '/')}` #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+            script {
+                if (env.BRANCH_NAME == 'master' || env.BRANCH_NAME =~ 'maintenance.*') {
+                    slackSend(color: '#c6c6c6', channel: "${SLACK_CHANNEL}", message: "ABORTED: `${env.JOB_NAME.replaceAll('%2F', '/')}` #${env.BUILD_NUMBER} (<${env.BUILD_URL}|Open>)")
+                }
+            }
         }
     }
-
 }


### PR DESCRIPTION
…branches

## Developer

**Link to the JIRA issue**
- https://jira.talendforge.org/browse/TDQ-17834

**What is the problem this Pull Request is trying to solve?**
 Slack messages are sent for every failing build on every branch, which is too much.
**What is the chosen solution to this problem?**
  Only send slack messages for master and maintenance branches
 
**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

## Reviewer

**Please check if the Pull Request fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] (if needed) Docs have been added / updated
- [ ] Changelog has been updated
