### PR TITLE
Fix(TDQ-18064) : Don't update daikon version when empty

### DIFF
--- a/dataquality-libraries-devops/src/main/java/org/talend/dataquality/libraries/devops/UpdateComponentDefinition.java
+++ b/dataquality-libraries-devops/src/main/java/org/talend/dataquality/libraries/devops/UpdateComponentDefinition.java
@@ -42,9 +42,9 @@ public class UpdateComponentDefinition {
 
     private static final String COMPONENTS_FOLDER = "/components"; //$NON-NLS-1$
 
-    private static final String DQ_LIB_VERSION = "8.0.0-SNAPSHOT"; //$NON-NLS-1$
+    private static final String DQ_LIB_VERSION = "8.0.0"; //$NON-NLS-1$
 
-    private static final String DAIKON_VERSION = "0.31.10-SNAPSHOT"; //$NON-NLS-1$
+    private static final String DAIKON_VERSION = ""; //$NON-NLS-1$
 
     private static final String[] PROVIDERS = new String[] { //
             "/org.talend.designer.components.tdqprovider", // //$NON-NLS-1$
@@ -81,34 +81,36 @@ public class UpdateComponentDefinition {
         if (Files.exists(filePath)) {
             try {
                 List<String> lines = Files.readAllLines(filePath);
-                boolean needUpdate = false;
+                Map<String, String> linesToUpdate = new HashMap<>();
                 for (String line : lines) {
                     for (String depName : DEP_VERSION_MAP.keySet()) {
-                        if (line.contains(depName)) {
-                            needUpdate = true;
-                            break;
+                        if (line.contains(depName) && !DEP_VERSION_MAP.get(depName).isEmpty()) {
+                            linesToUpdate.put(line, depName);
                         }
                     }
                 }
 
-                if (needUpdate) {
+                if (!linesToUpdate.isEmpty()) {
                     System.out.println("Updating: " + f.getName()); // NOSONAR
                     DataOutputStream writer = new DataOutputStream(Files.newOutputStream(filePath));
                     for (String line : lines) {
-                        for (String depName : DEP_VERSION_MAP.keySet()) {
-                            if (line.contains(depName)) {
-                                System.out.println(depName); // NOSONAR
-                                // MODULE field
-                                line = line.replaceAll(depName + "-\\d\\d?.\\d\\d?.\\d\\d?(-SNAPSHOT)?(.jar)?\"", //$NON-NLS-1$
-                                        depName + "-" + DEP_VERSION_MAP.get(depName) + "$2\""); //$NON-NLS-1$ //$NON-NLS-2$
-                                // MVN field
-                                line = line.replaceAll(depName + "/\\d\\d?.\\d\\d?.\\d\\d?(-SNAPSHOT)?(.jar)?\"", //$NON-NLS-1$
-                                        depName + "/" + DEP_VERSION_MAP.get(depName) + "$2\""); //$NON-NLS-1$ //$NON-NLS-2$
-                                // UrlPath field
-                                line = line.replaceAll(depName.replace('-', '.') + "_\\d\\d?.\\d\\d?.\\d\\d?(.SNAPSHOT)?.jar\"", //$NON-NLS-1$
-                                        depName.replace('-', '.') + "_" + DEP_VERSION_MAP.get(depName).replace('-', '.') //$NON-NLS-1$
-                                                + ".jar\""); //$NON-NLS-1$
-                            }
+                        if (linesToUpdate.containsKey(line)) {
+                            String depName = linesToUpdate.get(line);
+                            System.out.println(depName); // NOSONAR
+                            // MODULE field
+                            line = line
+                                    .replaceAll(depName + "-\\d\\d?.\\d\\d?.\\d\\d?(-SNAPSHOT)?(.jar)?\"", //$NON-NLS-1$
+                                            depName + "-" + DEP_VERSION_MAP.get(depName) + "$2\""); //$NON-NLS-1$ //$NON-NLS-2$
+                            // MVN field
+                            line = line
+                                    .replaceAll(depName + "/\\d\\d?.\\d\\d?.\\d\\d?(-SNAPSHOT)?(.jar)?\"", //$NON-NLS-1$
+                                            depName + "/" + DEP_VERSION_MAP.get(depName) + "$2\""); //$NON-NLS-1$ //$NON-NLS-2$
+                            // UrlPath field
+                            line = line
+                                    .replaceAll(
+                                            depName.replace('-', '.') + "_\\d\\d?.\\d\\d?.\\d\\d?(.SNAPSHOT)?.jar\"", //$NON-NLS-1$
+                                            depName.replace('-', '.') + "_" //$NON-NLS-1$
+                                                    + DEP_VERSION_MAP.get(depName).replace('-', '.') + ".jar\""); //$NON-NLS-1$
                         }
                         writer.write((line + "\n").getBytes(StandardCharsets.UTF_8)); //$NON-NLS-1$
                     }
@@ -125,11 +127,19 @@ public class UpdateComponentDefinition {
     public static void main(String[] args) {
 
         final String resourcePath = UpdateComponentDefinition.class.getResource(".").getFile(); //$NON-NLS-1$
-        final String projectRoot = new File(resourcePath).getParentFile().getParentFile().getParentFile().getParentFile()
-                .getParentFile().getParentFile().getParentFile().getPath() + File.separator;
+        final String projectRoot = new File(resourcePath)
+                .getParentFile()
+                .getParentFile()
+                .getParentFile()
+                .getParentFile()
+                .getParentFile()
+                .getParentFile()
+                .getParentFile()
+                .getPath() + File.separator;
 
         for (String provider : PROVIDERS) {
-            String componentRootPath = projectRoot + TDQ_STUDIO_EE_ROOT + MAIN_PLUGINS_FOLDER + provider + COMPONENTS_FOLDER;
+            String componentRootPath =
+                    projectRoot + TDQ_STUDIO_EE_ROOT + MAIN_PLUGINS_FOLDER + provider + COMPONENTS_FOLDER;
             System.out.println("\nProvider: " + provider); // NOSONAR
             File componentRoot = new File(componentRootPath);
             if (componentRoot.isDirectory()) {

--- a/dataquality-libraries-devops/src/main/java/org/talend/dataquality/libraries/devops/UpdateComponentDefinition.java
+++ b/dataquality-libraries-devops/src/main/java/org/talend/dataquality/libraries/devops/UpdateComponentDefinition.java
@@ -98,19 +98,15 @@ public class UpdateComponentDefinition {
                             String depName = linesToUpdate.get(line);
                             System.out.println(depName); // NOSONAR
                             // MODULE field
-                            line = line
-                                    .replaceAll(depName + "-\\d\\d?.\\d\\d?.\\d\\d?(-SNAPSHOT)?(.jar)?\"", //$NON-NLS-1$
-                                            depName + "-" + DEP_VERSION_MAP.get(depName) + "$2\""); //$NON-NLS-1$ //$NON-NLS-2$
+                            line = line.replaceAll(depName + "-\\d\\d?.\\d\\d?.\\d\\d?(-SNAPSHOT)?(.jar)?\"", //$NON-NLS-1$
+                                    depName + "-" + DEP_VERSION_MAP.get(depName) + "$2\""); //$NON-NLS-1$ //$NON-NLS-2$
                             // MVN field
-                            line = line
-                                    .replaceAll(depName + "/\\d\\d?.\\d\\d?.\\d\\d?(-SNAPSHOT)?(.jar)?\"", //$NON-NLS-1$
-                                            depName + "/" + DEP_VERSION_MAP.get(depName) + "$2\""); //$NON-NLS-1$ //$NON-NLS-2$
+                            line = line.replaceAll(depName + "/\\d\\d?.\\d\\d?.\\d\\d?(-SNAPSHOT)?(.jar)?\"", //$NON-NLS-1$
+                                    depName + "/" + DEP_VERSION_MAP.get(depName) + "$2\""); //$NON-NLS-1$ //$NON-NLS-2$
                             // UrlPath field
-                            line = line
-                                    .replaceAll(
-                                            depName.replace('-', '.') + "_\\d\\d?.\\d\\d?.\\d\\d?(.SNAPSHOT)?.jar\"", //$NON-NLS-1$
-                                            depName.replace('-', '.') + "_" //$NON-NLS-1$
-                                                    + DEP_VERSION_MAP.get(depName).replace('-', '.') + ".jar\""); //$NON-NLS-1$
+                            line = line.replaceAll(depName.replace('-', '.') + "_\\d\\d?.\\d\\d?.\\d\\d?(.SNAPSHOT)?.jar\"", //$NON-NLS-1$
+                                    depName.replace('-', '.') + "_" //$NON-NLS-1$
+                                            + DEP_VERSION_MAP.get(depName).replace('-', '.') + ".jar\""); //$NON-NLS-1$
                         }
                         writer.write((line + "\n").getBytes(StandardCharsets.UTF_8)); //$NON-NLS-1$
                     }
@@ -127,19 +123,11 @@ public class UpdateComponentDefinition {
     public static void main(String[] args) {
 
         final String resourcePath = UpdateComponentDefinition.class.getResource(".").getFile(); //$NON-NLS-1$
-        final String projectRoot = new File(resourcePath)
-                .getParentFile()
-                .getParentFile()
-                .getParentFile()
-                .getParentFile()
-                .getParentFile()
-                .getParentFile()
-                .getParentFile()
-                .getPath() + File.separator;
+        final String projectRoot = new File(resourcePath).getParentFile().getParentFile().getParentFile().getParentFile()
+                .getParentFile().getParentFile().getParentFile().getPath() + File.separator;
 
         for (String provider : PROVIDERS) {
-            String componentRootPath =
-                    projectRoot + TDQ_STUDIO_EE_ROOT + MAIN_PLUGINS_FOLDER + provider + COMPONENTS_FOLDER;
+            String componentRootPath = projectRoot + TDQ_STUDIO_EE_ROOT + MAIN_PLUGINS_FOLDER + provider + COMPONENTS_FOLDER;
             System.out.println("\nProvider: " + provider); // NOSONAR
             File componentRoot = new File(componentRootPath);
             if (componentRoot.isDirectory()) {


### PR DESCRIPTION
## Developer

**Link to the JIRA issue**
- https://jira.talendforge.org/browse/TDQ-18064

**What is the problem this Pull Request is trying to solve?**
 The script is always trying to update daikon version with the value set in parameters.
**What is the chosen solution to this problem?**
  Don't update daikon version when it is empty
 
**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

## Reviewer

**Please check if the Pull Request fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] (if needed) Docs have been added / updated
- [ ] Changelog has been updated
