### PR TITLE
TDQ-18375 - Update Log4j 2 to 2.13.2

### DIFF
--- a/dataquality-libraries/pom.xml
+++ b/dataquality-libraries/pom.xml
@@ -18,7 +18,7 @@
 
 		<slf4j.version>1.7.12</slf4j.version>
 		<log4j.version>1.2.17</log4j.version>
-		<log4j2.version>2.4.1</log4j2.version>
+		<log4j2.version>2.13.2</log4j2.version>
 		<java.version>1.8</java.version>
 		<assertj.version>3.0.0</assertj.version>
 		<junit.version>4.12</junit.version>


### PR DESCRIPTION


This task is to update Log4j 2 to 2.13.2 due to the following CVE:

[CVE-2020-9488] Improper validation of certificate with host mismatch in Apache Log4j SMTP appender

https://seclists.org/oss-sec/2020/q2/72
