### PR TITLE
Fix/yyin/tdq 18347 concatenate not compare original--backport to 74

### DIFF
--- a/dataquality-record-linkage/CHANGELOG.md
+++ b/dataquality-record-linkage/CHANGELOG.md
@@ -18,7 +18,10 @@ N/A
 ### Security
 N/A
 
-## [7.4.1] - 2019-12-11
+## [7.4.1] - 2020-05-22
+### Fixed
+- TDQ-18347 Modify the CONcatenate function when matching: only use the original values to match, but not the concatenated value.
+
 ### Added
 - chore(TDQ-17710): Adopt the "Keep a Changelog" format for changelogs
 

--- a/dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/Attribute.java
+++ b/dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/Attribute.java
@@ -16,11 +16,11 @@
  */
 package org.talend.dataquality.matchmerge;
 
+import org.apache.commons.collections.iterators.IteratorChain;
+
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Iterator;
-
-import org.apache.commons.collections.iterators.IteratorChain;
 
 /**
  * A attribute is a "column" in a {@link org.talend.dataquality.matchmerge.Record record}.

--- a/dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/mfb/MFB.java
+++ b/dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/mfb/MFB.java
@@ -78,7 +78,7 @@ public class MFB implements MatchMergeAlgorithm {
     public static MFB build(AttributeMatcherType[] algorithms, String[] algorithmParameters, float[] thresholds,
             double minConfidenceValue, SurvivorShipAlgorithmEnum[] merges, String[] mergesParameters, double[] weights,
             IAttributeMatcher.NullOption[] nullOptions, SubString[] subStrings, String mergedRecordSource) {
-        IRecordMatcher newMatcher = new MFBRecordMatcher(minConfidenceValue);
+        MFBRecordMatcher newMatcher = new MFBRecordMatcher(minConfidenceValue);
         newMatcher.setRecordSize(algorithms.length);
         // Create attribute match
         IAttributeMatcher[] attributeMatchers = new IAttributeMatcher[algorithms.length];
@@ -104,6 +104,8 @@ public class MFB implements MatchMergeAlgorithm {
         newMatcher.setRecordMatchThreshold(minConfidenceValue);
         // Attribute weights
         newMatcher.setAttributeWeights(weights);
+        //Survivorship function , TDQ-18347 
+        newMatcher.setSurvivorShipFunction(merges);
         // Create MFB instance
         return new MFB(newMatcher, new MFBRecordMerger(mergedRecordSource, mergesParameters, merges));
     }

--- a/dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/mfb/MFBRecordMatcher.java
+++ b/dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/mfb/MFBRecordMatcher.java
@@ -12,10 +12,6 @@
 // ============================================================================
 package org.talend.dataquality.matchmerge.mfb;
 
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
 import org.apache.commons.collections.iterators.IteratorChain;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -24,6 +20,11 @@ import org.talend.dataquality.matchmerge.Attribute;
 import org.talend.dataquality.matchmerge.Record;
 import org.talend.dataquality.record.linkage.attribute.IAttributeMatcher;
 import org.talend.dataquality.record.linkage.record.AbstractRecordMatcher;
+import org.talend.dataquality.record.linkage.utils.SurvivorShipAlgorithmEnum;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
 
 public class MFBRecordMatcher extends AbstractRecordMatcher {
 
@@ -32,6 +33,9 @@ public class MFBRecordMatcher extends AbstractRecordMatcher {
     private final double minConfidenceValue;
 
     private static double worstConfidenceValue;
+
+    //Added TDQ-18347,20200515 , one key <-> one survivorship function
+    private static String[] survivorshipFunctions;
 
     public MFBRecordMatcher(double minConfidenceValue) {
         this.minConfidenceValue = minConfidenceValue;
@@ -72,7 +76,7 @@ public class MFBRecordMatcher extends AbstractRecordMatcher {
             Double rightWorstScore = getWorstScore(rightWorstConfidenceValueScoreList, matchIndex);
             // Find the first score to exceed threshold (if any).
             // use record1.getWorstConfidenceValueScoreList() to instead of some while in matchScore method
-            double score = matchScore(left, right, matcher, leftWorstScore, rightWorstScore);
+            double score = matchScore(left, right, matcher, leftWorstScore, rightWorstScore, matchIndex);
             attributeMatchingWeights[matchIndex] = score;
             result.setScore(matchIndex, matcher.getMatchType(), score, record1.getId(), left.getValue(), record2.getId(),
                     right.getValue());
@@ -118,15 +122,13 @@ public class MFBRecordMatcher extends AbstractRecordMatcher {
         record2.setConfidence(normalizedConfidence);
     }
 
+    @SuppressWarnings("unchecked")
     private static double matchScore(Attribute leftAttribute, Attribute rightAttribute, IAttributeMatcher matcher,
-            Double leftWorstScore, Double rightWorstScore) {
+            Double leftWorstScore, Double rightWorstScore, int matchIndex) {
         // Find the best score in values
         // 1- Try first values
-        String left = leftAttribute.getValue();
-        String right = rightAttribute.getValue();
         // 2- Compare using values that build attribute value (if any)
-        Iterator<String> leftValues = new IteratorChain(Collections.singleton(left).iterator(),
-                leftAttribute.getValues().iterator());
+        Iterator<String> leftValues = getAllComparedValues(leftAttribute, matchIndex);
 
         double maxScore = 0;
         double score = 0;
@@ -138,8 +140,7 @@ public class MFBRecordMatcher extends AbstractRecordMatcher {
 
         while (leftValues.hasNext()) {
             String leftValue = leftValues.next();
-            Iterator<String> rightValues = new IteratorChain(Collections.singleton(right).iterator(),
-                    rightAttribute.getValues().iterator());
+            Iterator<String> rightValues = getAllComparedValues(rightAttribute, matchIndex);
             while (rightValues.hasNext()) {
                 String rightValue = rightValues.next();
                 score = matcher.getMatchingWeight(leftValue, rightValue);
@@ -163,4 +164,47 @@ public class MFBRecordMatcher extends AbstractRecordMatcher {
         return this.worstConfidenceValue;
     }
 
+    /**
+     * keep survivorFunction in the matcher, maybe still need it in future
+     * @param survivorShipFunctions
+     */
+    public void setSurvivorShipFunction(String[] survivorShipFunctions) {
+        survivorshipFunctions = survivorShipFunctions;
+    }
+
+    /**
+     * TDQ-18347 when using CONCATENATE in match key, then no need to compare its concatednated value for generated masters.
+     * but for the first time, need to use its original value.
+     * @param comparedAttribute
+     * @return
+     */
+    protected static IteratorChain getAllComparedValues(Attribute comparedAttribute, int matchIndex) {
+        if (survivorshipFunctions != null && survivorshipFunctions.length > matchIndex
+                && SurvivorShipAlgorithmEnum.CONCATENATE
+                        .getValue()
+                        .equalsIgnoreCase(survivorshipFunctions[matchIndex])) {
+            if (comparedAttribute.getValues().size() > 0) {
+                return new IteratorChain(comparedAttribute.getValues().iterator());
+            }
+        }
+        return new IteratorChain(Collections.singleton(comparedAttribute.getValue()).iterator(),
+                comparedAttribute.getValues().iterator());
+    }
+
+    /**
+     * TDQ-18347 , for : SurvivorShipAlgorithmEnum.CONCATENATE, the concatenated value of the master 
+     * will not attend the matching anymore, only use the original values to match from this issue
+     * This method is called from MFB.build, but not on DQ side
+     * @param surAlgorithms
+     */
+    public void setSurvivorShipFunction(SurvivorShipAlgorithmEnum[] surAlgorithms) {
+        if (surAlgorithms != null && surAlgorithms.length > 0) {
+            survivorshipFunctions = new String[surAlgorithms.length];
+            int index = 0;
+            for (SurvivorShipAlgorithmEnum sAlgorithm : surAlgorithms) {
+                survivorshipFunctions[index++] = sAlgorithm.getValue();
+            }
+        }
+
+    }
 }

--- a/dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/mfb/MFBRecordMerger.java
+++ b/dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/mfb/MFBRecordMerger.java
@@ -12,6 +12,13 @@
 // ============================================================================
 package org.talend.dataquality.matchmerge.mfb;
 
+import org.apache.commons.lang.StringUtils;
+import org.talend.dataquality.matchmerge.Attribute;
+import org.talend.dataquality.matchmerge.AttributeValues;
+import org.talend.dataquality.matchmerge.Record;
+import org.talend.dataquality.record.linkage.record.IRecordMerger;
+import org.talend.dataquality.record.linkage.utils.SurvivorShipAlgorithmEnum;
+
 import java.math.BigDecimal;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -19,13 +26,6 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.lang.StringUtils;
-import org.talend.dataquality.matchmerge.Attribute;
-import org.talend.dataquality.matchmerge.AttributeValues;
-import org.talend.dataquality.matchmerge.Record;
-import org.talend.dataquality.record.linkage.record.IRecordMerger;
-import org.talend.dataquality.record.linkage.utils.SurvivorShipAlgorithmEnum;
 
 public class MFBRecordMerger implements IRecordMerger {
 

--- a/dataquality-record-linkage/src/main/java/org/talend/dataquality/record/linkage/grouping/AbstractRecordGrouping.java
+++ b/dataquality-record-linkage/src/main/java/org/talend/dataquality/record/linkage/grouping/AbstractRecordGrouping.java
@@ -12,13 +12,6 @@
 // ============================================================================
 package org.talend.dataquality.record.linkage.grouping;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
-
 import org.apache.commons.lang.StringUtils;
 import org.talend.dataquality.matchmerge.SubString;
 import org.talend.dataquality.matchmerge.mfb.MFBAttributeMatcher;
@@ -31,11 +24,19 @@ import org.talend.dataquality.record.linkage.constant.TokenizedResolutionMethod;
 import org.talend.dataquality.record.linkage.grouping.swoosh.DQMFBRecordMatcher;
 import org.talend.dataquality.record.linkage.grouping.swoosh.RichRecord;
 import org.talend.dataquality.record.linkage.grouping.swoosh.SurvivorShipAlgorithmParams;
+import org.talend.dataquality.record.linkage.grouping.swoosh.SurvivorshipUtils;
 import org.talend.dataquality.record.linkage.record.CombinedRecordMatcher;
 import org.talend.dataquality.record.linkage.record.IRecordMatcher;
 import org.talend.dataquality.record.linkage.record.RecordMatcherFactory;
 import org.talend.dataquality.record.linkage.utils.CustomAttributeMatcherClassNameConvert;
 import org.talend.utils.classloader.TalendURLClassLoader;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * created by zhao on Jul 19, 2013 <br>
@@ -529,6 +530,7 @@ public abstract class AbstractRecordGrouping<TYPE> implements IRecordGrouping<TY
         String[][] algorithmName = new String[recordSize][2];
         String[] arrMatchHandleNull = new String[recordSize];
         String[] customizedJarPath = new String[recordSize];
+        String[] survivorShipFunctions = new String[recordSize];
         TokenizedResolutionMethod[] tokenMethod = new TokenizedResolutionMethod[recordSize];
         double recordMatchThreshold = acceptableThreshold;// keep compatibility to older version.
         boolean isSwoosh = matchAlgo == RecordMatcherType.T_SwooshAlgorithm;
@@ -565,6 +567,8 @@ public abstract class AbstractRecordGrouping<TYPE> implements IRecordGrouping<TY
                 recordMatchThreshold = Double.valueOf(rcdMathThresholdEach);
 
             }
+            //Added TDQ-18347.
+            survivorShipFunctions[keyIdx] = recordMap.get(SurvivorshipUtils.SURVIVORSHIP_FUNCTION);
             keyIdx++;
         }
         IAttributeMatcher[] attributeMatcher = new IAttributeMatcher[recordSize];
@@ -597,6 +601,7 @@ public abstract class AbstractRecordGrouping<TYPE> implements IRecordGrouping<TY
         IRecordMatcher recordMatcher = RecordMatcherFactory.createMatcher(RecordMatcherType.simpleVSRMatcher);
         if (isSwoosh) {
             recordMatcher = new DQMFBRecordMatcher(recordMatchThreshold);
+            ((DQMFBRecordMatcher) recordMatcher).setSurvivorShipFunction(survivorShipFunctions);
         }
         recordMatcher.setRecordSize(recordSize);
         recordMatcher.setAttributeWeights(arrAttrWeights);

--- a/dataquality-record-linkage/src/test/java/org/talend/dataquality/matchmerge/mfb/MFBOrderTest.java
+++ b/dataquality-record-linkage/src/test/java/org/talend/dataquality/matchmerge/mfb/MFBOrderTest.java
@@ -1,10 +1,6 @@
 package org.talend.dataquality.matchmerge.mfb;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import junit.framework.TestCase;
 import org.junit.Assert;
 import org.talend.dataquality.matchmerge.Attribute;
 import org.talend.dataquality.matchmerge.MatchMergeAlgorithm;
@@ -15,7 +11,10 @@ import org.talend.dataquality.record.linkage.attribute.IAttributeMatcher;
 import org.talend.dataquality.record.linkage.constant.AttributeMatcherType;
 import org.talend.dataquality.record.linkage.utils.SurvivorShipAlgorithmEnum;
 
-import junit.framework.TestCase;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MFBOrderTest extends TestCase {
 
@@ -170,7 +169,7 @@ public class MFBOrderTest extends TestCase {
         List<Record> mergeRecordList3 = algorithm.execute(listOrder3.iterator(), callback);
         printResult(mergeRecordList3);
         Assert.assertTrue(assertResult(mergeRecordList1, mergeRecordList2));
-        Assert.assertTrue(assertResult(mergeRecordList1, mergeRecordList3, true, new Integer[] { 1 }));
+        Assert.assertTrue(assertResult(mergeRecordList1, mergeRecordList3));
     }
 
     private boolean assertResult(List<Record> expectMergeRecordList, List<Record> actualMergeRecordList) {

--- a/dataquality-record-linkage/src/test/java/org/talend/dataquality/matchmerge/mfb/MFBRecordMatcherTest.java
+++ b/dataquality-record-linkage/src/test/java/org/talend/dataquality/matchmerge/mfb/MFBRecordMatcherTest.java
@@ -18,8 +18,10 @@ import org.junit.Test;
 import org.talend.dataquality.matchmerge.Attribute;
 import org.talend.dataquality.matchmerge.Record;
 import org.talend.dataquality.matchmerge.SubString;
+import org.talend.dataquality.record.linkage.attribute.ExactMatcher;
 import org.talend.dataquality.record.linkage.attribute.IAttributeMatcher;
 import org.talend.dataquality.record.linkage.attribute.JaroMatcher;
+import org.talend.dataquality.record.linkage.utils.SurvivorShipAlgorithmEnum;
 
 /**
  * DOC zshen class global comment. Detailled comment
@@ -154,5 +156,124 @@ public class MFBRecordMatcherTest {
         Assert.assertTrue("setAttributeMatchers fail", mfbRecordMatcher.setAttributeMatchers(attributeMatchers)); //$NON-NLS-1$
         MatchResult matchingResult = mfbRecordMatcher.getMatchingWeight(record1, record2);
         Assert.assertEquals("1.0", String.valueOf(matchingResult.getScores().get(0).score)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void test_tdq18347() {
+        // init record
+        String[] survivorShipFunctions = new String[1];
+        survivorShipFunctions[0] = SurvivorShipAlgorithmEnum.CONCATENATE.getValue();
+        Record record1 = new Record(null, 0, StringUtils.EMPTY);
+        Attribute attribute = new Attribute("0"); //$NON-NLS-1$
+        // add master value
+        attribute.setValue("jinanjinan"); //$NON-NLS-1$
+        // sub element value
+        attribute.getValues().get("jinan").increment(); //$NON-NLS-1$
+        ;
+        record1.getAttributes().add(attribute);
+
+        Record record2 = new Record(null, 0, StringUtils.EMPTY);
+        attribute = new Attribute("1"); //$NON-NLS-1$
+        // add master value
+        attribute.setValue("jinanjinan"); //$NON-NLS-1$
+        record2.getAttributes().add(attribute);
+
+        Record record3 = new Record(null, 0, StringUtils.EMPTY);
+        attribute = new Attribute("2"); //$NON-NLS-1$
+        // add master value
+        attribute.setValue("jinan"); //$NON-NLS-1$
+        record3.getAttributes().add(attribute);
+
+        Record record4 = new Record(null, 0, StringUtils.EMPTY);
+        attribute = new Attribute("3"); //$NON-NLS-1$
+        // add master value
+        attribute.setValue("jinan"); //$NON-NLS-1$
+        record4.getAttributes().add(attribute);
+
+        // init Attribute matcher
+        IAttributeMatcher[] attributeMatchers = new IAttributeMatcher[] {
+                MFBAttributeMatcher.wrap(new ExactMatcher(), 1.0, 1.0, SubString.NO_SUBSTRING) };
+
+        MFBRecordMatcher mfbRecordMatcher = new MFBRecordMatcher(0.85d);
+        mfbRecordMatcher.setSurvivorShipFunction(survivorShipFunctions);
+        mfbRecordMatcher.setRecordSize(1);
+        mfbRecordMatcher.setAttributeMatchers(attributeMatchers);
+
+        MatchResult matchingResult = mfbRecordMatcher.getMatchingWeight(record1, record2);
+        Assert.assertEquals("0.0", String.valueOf(matchingResult.getScores().get(0).score)); //$NON-NLS-1$
+
+        matchingResult = mfbRecordMatcher.getMatchingWeight(record1, record3);
+        Assert.assertEquals("1.0", String.valueOf(matchingResult.getScores().get(0).score)); //$NON-NLS-1$
+
+        matchingResult = mfbRecordMatcher.getMatchingWeight(record4, record3);
+        Assert.assertEquals("1.0", String.valueOf(matchingResult.getScores().get(0).score)); //$NON-NLS-1$
+    }
+
+    @Test
+    public void test_tdq18347_2() {
+        // 2 different functions and 2 matchers
+        String[] survivorShipFunctions = new String[2];
+        survivorShipFunctions[0] = SurvivorShipAlgorithmEnum.CONCATENATE.getValue();
+        survivorShipFunctions[1] = SurvivorShipAlgorithmEnum.MOST_COMMON.getValue();
+        Record record1 = new Record(null, 0, StringUtils.EMPTY);
+        Attribute attribute = new Attribute("0"); //$NON-NLS-1$
+        attribute.setValue("jinanjinan"); //$NON-NLS-1$
+        attribute.getValues().get("jinan").increment();//$NON-NLS-1$
+        record1.getAttributes().add(attribute);
+        attribute = new Attribute("1"); //$NON-NLS-1$
+        attribute.setValue("CCC"); //$NON-NLS-1$
+        attribute.getValues().get("CC").increment();//$NON-NLS-1$
+        record1.getAttributes().add(attribute);
+
+        Record record2 = new Record(null, 0, StringUtils.EMPTY);
+        attribute = new Attribute("0"); //$NON-NLS-1$
+        attribute.setValue("jinanjinan"); //$NON-NLS-1$
+        record2.getAttributes().add(attribute);
+        attribute = new Attribute("1"); //$NON-NLS-1$
+        attribute.setValue("CC"); //$NON-NLS-1$
+        record2.getAttributes().add(attribute);
+
+        Record record3 = new Record(null, 0, StringUtils.EMPTY);
+        attribute = new Attribute("0"); //$NON-NLS-1$
+        attribute.setValue("jinan"); //$NON-NLS-1$
+        record3.getAttributes().add(attribute);
+        attribute = new Attribute("1"); //$NON-NLS-1$
+        attribute.setValue("CC"); //$NON-NLS-1$
+        record3.getAttributes().add(attribute);
+
+        Record record4 = new Record(null, 0, StringUtils.EMPTY);
+        attribute = new Attribute("0"); //$NON-NLS-1$
+        attribute.setValue("jinan"); //$NON-NLS-1$
+        record4.getAttributes().add(attribute);
+        attribute = new Attribute("1"); //$NON-NLS-1$
+        attribute.setValue("CCC"); //$NON-NLS-1$
+        record4.getAttributes().add(attribute);
+
+        // init Attribute matcher
+        IAttributeMatcher[] attributeMatchers = new IAttributeMatcher[] {
+                MFBAttributeMatcher.wrap(new ExactMatcher(), 1.0, 1.0, SubString.NO_SUBSTRING),
+                MFBAttributeMatcher.wrap(new ExactMatcher(), 1.0, 1.0, SubString.NO_SUBSTRING) };
+
+        MFBRecordMatcher mfbRecordMatcher = new MFBRecordMatcher(0.85d);
+        mfbRecordMatcher.setSurvivorShipFunction(survivorShipFunctions);
+        mfbRecordMatcher.setRecordSize(2);
+        mfbRecordMatcher.setAttributeMatchers(attributeMatchers);
+
+        MatchResult matchingResult = mfbRecordMatcher.getMatchingWeight(record1, record2);
+        Assert.assertEquals("0.0", String.valueOf(matchingResult.getScores().get(0).score)); //$NON-NLS-1$
+        Assert.assertEquals("1.0", String.valueOf(matchingResult.getScores().get(1).score));
+
+        matchingResult = mfbRecordMatcher.getMatchingWeight(record1, record3);
+        Assert.assertEquals("1.0", String.valueOf(matchingResult.getScores().get(0).score)); //$NON-NLS-1$
+        Assert.assertEquals("1.0", String.valueOf(matchingResult.getScores().get(1).score));
+
+        matchingResult = mfbRecordMatcher.getMatchingWeight(record4, record3);
+        Assert.assertEquals("1.0", String.valueOf(matchingResult.getScores().get(0).score)); //$NON-NLS-1$
+        Assert.assertEquals("0.0", String.valueOf(matchingResult.getScores().get(1).score));
+
+        matchingResult = mfbRecordMatcher.getMatchingWeight(record1, record4);
+        Assert.assertEquals("1.0", String.valueOf(matchingResult.getScores().get(0).score)); //$NON-NLS-1$
+        Assert.assertEquals("1.0", String.valueOf(matchingResult.getScores().get(1).score));
+        Assert.assertEquals("1.0", String.valueOf(matchingResult.getNormalizedConfidence()));
     }
 }

--- a/dataquality-record-linkage/src/test/java/org/talend/dataquality/matchmerge/mfb/MultiColumnMFBOrderTest.java
+++ b/dataquality-record-linkage/src/test/java/org/talend/dataquality/matchmerge/mfb/MultiColumnMFBOrderTest.java
@@ -191,8 +191,8 @@ public class MultiColumnMFBOrderTest extends TestCase {
         System.out.println("\nOrder 3:  "); //$NON-NLS-1$
         List<Record> mergeRecordList3 = algorithm.execute(listOrder3.iterator(), callback);
         printResult(mergeRecordList3);
-        Assert.assertTrue(assertResult(mergeRecordList1, mergeRecordList2, true, new Integer[] { 0 }));
-        Assert.assertTrue(assertResult(mergeRecordList1, mergeRecordList3, true, new Integer[] { 0 }));
+        Assert.assertTrue(assertResult(mergeRecordList1, mergeRecordList2));
+        Assert.assertTrue(assertResult(mergeRecordList1, mergeRecordList3));
         Assert.assertTrue(assertResult(mergeRecordList2, mergeRecordList3));
     }
 

--- a/dataquality-record-linkage/src/test/java/org/talend/dataquality/record/linkage/grouping/SwooshRecordGroupingTest.java
+++ b/dataquality-record-linkage/src/test/java/org/talend/dataquality/record/linkage/grouping/SwooshRecordGroupingTest.java
@@ -3688,11 +3688,10 @@ public class SwooshRecordGroupingTest {
         // assert
         Assert.assertTrue(groupRows_tMatchGroup_1.size() > 0);
         for (row2Struct one : groupRows_tMatchGroup_1) {
-            // System.out.println(one.customer_id + "--" + one.city + "--" + one.country + "--" + one.GID + "--" +
-            // one.GRP_QUALITY+ "--" + one.MASTER);
+            //             System.out.println(one.customer_id + "--" + one.city + "--" + one.country + "--" + one.GID + "--" +
+            //             one.GRP_QUALITY+ "--" + one.MASTER+"--"+one.SCORE);
             if (one.MASTER) {
-                Assert.assertTrue(0 == one.GRP_QUALITY && 1 == one.SCORE);
-
+                Assert.assertTrue(1 == one.GRP_QUALITY && 1 == one.SCORE);
             }
         }
     }
@@ -4300,6 +4299,103 @@ public class SwooshRecordGroupingTest {
                 Assert.assertEquals("2015-01-03 11:05:20.111", rds[5]);
             }
         }
+    }
+
+    @Test
+    public void testSwooshIntMatchGroup_tdq18347() throws IOException, InterruptedException, InstantiationException,
+            IllegalAccessException, ClassNotFoundException {
+        List<List<Map<String, String>>> matchingRulesAll_tMatchGroup_1 = new ArrayList<List<Map<String, String>>>();
+        List<Map<String, String>> matcherList_tMatchGroup_1 = null;
+        Map<String, String> tmpMap_tMatchGroup_1 = null;
+        List<Map<String, String>> defaultSurvivorshipRules_tMatchGroup_1 = new ArrayList<Map<String, String>>();
+        matcherList_tMatchGroup_1 = new ArrayList<Map<String, String>>();
+        tmpMap_tMatchGroup_1 = createTmpMap("CONCATENATE", "1", "", "country", "2", "Exact", "NO", 1 + "",
+                "nullMatchNull", 0.85 + "", "TSWOOSH_MATCHER");
+        matcherList_tMatchGroup_1.add(tmpMap_tMatchGroup_1);
+        matchingRulesAll_tMatchGroup_1.add(matcherList_tMatchGroup_1);
+        // master rows in a group
+        final List<row2Struct> masterRows_tMatchGroup_1 = new ArrayList<row2Struct>();
+        // all rows in a group
+        final List<row2Struct> groupRows_tMatchGroup_1 = new ArrayList<row2Struct>();
+        // this Map key is MASTER GID,value is this MASTER index of all
+        // MASTERS.it will be used to get DUPLICATE GRP_QUALITY from
+        // MASTER and only in case of separate output.
+        final Map<String, Integer> indexMap_tMatchGroup_1 = new HashMap<String, Integer>();
+
+        // TDQ-9172 reuse JAVA API at here.
+        AbstractRecordGrouping<Object> recordGroupImp_tMatchGroup_1 =
+                createComponent(masterRows_tMatchGroup_1, groupRows_tMatchGroup_1, indexMap_tMatchGroup_1);
+
+        recordGroupImp_tMatchGroup_1.setRecordLinkAlgorithm(RecordMatcherType.T_SwooshAlgorithm);
+        // add mutch rules
+        for (List<Map<String, String>> matcherList : matchingRulesAll_tMatchGroup_1) {
+            recordGroupImp_tMatchGroup_1.addMatchRule(matcherList);
+        }
+        recordGroupImp_tMatchGroup_1.initialize();
+        // init the parameters of the tswoosh algorithm
+        Map<String, String> columnWithType_tMatchGroup_1 = fillColumn("id_Integer", "id_String", "id_String",
+                "id_String", "id_Integer", "id_Boolean", "id_Double", "id_Double", null);
+        Map<String, String> columnWithIndex_tMatchGroup_1 = fillColumn("0", "1", "2", "3", "4", "5", "6", "7", null);
+
+        SurvivorShipAlgorithmParams survivorShipAlgorithmParams_tMatchGroup_1 = SurvivorshipUtils
+                .createSurvivorShipAlgorithmParams((AnalysisSwooshMatchRecordGrouping) recordGroupImp_tMatchGroup_1,
+                        matchingRulesAll_tMatchGroup_1, defaultSurvivorshipRules_tMatchGroup_1,
+                        columnWithType_tMatchGroup_1, columnWithIndex_tMatchGroup_1);
+        ((AnalysisSwooshMatchRecordGrouping) recordGroupImp_tMatchGroup_1)
+                .setSurvivorShipAlgorithmParams(survivorShipAlgorithmParams_tMatchGroup_1);
+        initialize(recordGroupImp_tMatchGroup_1);
+
+        // read the data from the file
+        InputStream in = this.getClass().getResourceAsStream("swoosh_18347.txt"); //$NON-NLS-1$
+        BufferedReader bfr = new BufferedReader(new InputStreamReader(in));
+        List<String> listOfLines = IOUtils.readLines(bfr);
+        inputList = new ArrayList<String[]>();
+        List<String[]> inputList2 = new ArrayList<String[]>();
+        for (String line : listOfLines) {
+            String[] fields = StringUtils.splitPreserveAllTokens(line, columnDelimiter);
+            if (StringUtils.equals("F", fields[1])) {
+                inputList.add(fields);
+            } else {
+                inputList2.add(fields);
+            }
+        }
+
+        for (String[] inputRow : inputList) { // loop on each data
+            recordGroupImp_tMatchGroup_1.doGroup(inputRow);
+        } // while
+        recordGroupImp_tMatchGroup_1.end();
+
+        for (String[] inputRow : inputList2) { // loop on each data
+            recordGroupImp_tMatchGroup_1.doGroup(inputRow);
+        } // while
+        recordGroupImp_tMatchGroup_1.end();
+
+        groupRows_tMatchGroup_1.addAll(masterRows_tMatchGroup_1);
+
+        Collections.sort(groupRows_tMatchGroup_1);
+        //Assert.assertTrue(groupRows_tMatchGroup_1.size() > 10);
+        boolean hasGroup5 = false, hasGroup2 = false;
+        for (row2Struct one : groupRows_tMatchGroup_1) {
+            //             System.out.println(one.customer_id + "--" + one.city + "--" + one.country + "--" + one.GID + "--" +
+            //             one.GRP_SIZE+"--" + one.MASTER);
+            if ("CCC".equals(one.country)) {
+                hasGroup5 = true;
+                Assert.assertTrue(one.MASTER);
+                Assert.assertTrue(3 == one.GRP_SIZE || 1 == one.GRP_SIZE);
+            } else if ("AAA".equals(one.country)) {
+                hasGroup2 = true;
+                Assert.assertTrue(one.MASTER);
+                Assert.assertTrue(3 == one.GRP_SIZE || 1 == one.GRP_SIZE);
+            } else if ("AA".equals(one.country)) {
+                Assert.assertTrue(one.MASTER);
+                Assert.assertTrue(1 == one.GRP_SIZE);
+            } else if ("CC".equals(one.country)) {
+                Assert.assertTrue(one.MASTER);
+                Assert.assertTrue(1 == one.GRP_SIZE);
+            }
+        }
+        Assert.assertTrue(hasGroup5);
+        Assert.assertTrue(hasGroup2);
     }
 
     public static class row4Struct implements Comparable<row4Struct> {

--- a/dataquality-record-linkage/src/test/resources/org/talend/dataquality/record/linkage/grouping/swoosh_18347.txt
+++ b/dataquality-record-linkage/src/test/resources/org/talend/dataquality/record/linkage/grouping/swoosh_18347.txt
@@ -1,0 +1,10 @@
+0|F|A
+1|F|A
+2|M|C
+3|M|C
+4|F|AA
+5|M|CC
+6|F|AAA
+7|M|CCC
+8|M|C
+9|F|A


### PR DESCRIPTION
* Fix TDQ-18347 make the MFBRecordMatcher :
- when COncatenate, do not use the combined value to match.

Conflicts:
	dataquality-record-linkage/CHANGELOG.md
	dataquality-record-linkage/src/main/java/org/talend/dataquality/matchmerge/mfb/MFBRecordMatcher.java

## Developer

**Link to the JIRA issue**
- https://jira.talendforge.org/browse/TDQ-XXXXX

**What is the problem this Pull Request is trying to solve?**
 
**What is the chosen solution to this problem?**
  
 
**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

## Reviewer

**Please check if the Pull Request fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] (if needed) Docs have been added / updated
- [ ] Changelog has been updated
