### PR TITLE
fix(TDQ-18518): add studio lib version for **.datamart jar

### DIFF
--- a/dataquality-libraries-devops/src/main/java/org/talend/dataquality/libraries/devops/UpdateComponentDefinition.java
+++ b/dataquality-libraries-devops/src/main/java/org/talend/dataquality/libraries/devops/UpdateComponentDefinition.java
@@ -44,6 +44,8 @@ public class UpdateComponentDefinition {
 
     private static final String DQ_LIB_VERSION = "8.3.1-SNAPSHOT"; //$NON-NLS-1$
 
+    private static final String DQ_STUDIO_LIB_VERSION = "7.4.1-SNAPSHOT"; //$NON-NLS-1$
+
     private static final String DAIKON_VERSION = ""; //$NON-NLS-1$
 
     private static final String[] PROVIDERS = new String[] { //
@@ -70,6 +72,7 @@ public class UpdateComponentDefinition {
         DEP_VERSION_MAP.put("org.talend.dataquality.survivorship", DQ_LIB_VERSION); //$NON-NLS-1$
         DEP_VERSION_MAP.put("org.talend.dataquality.text.japanese", DQ_LIB_VERSION); //$NON-NLS-1$
         DEP_VERSION_MAP.put("org.talend.dataquality.statistics", DQ_LIB_VERSION); //$NON-NLS-1$
+        DEP_VERSION_MAP.put("org.talend.dataprofiler.datamart", DQ_STUDIO_LIB_VERSION); //$NON-NLS-1$
     }
 
     private UpdateComponentDefinition() {


### PR DESCRIPTION
## Developer

**Link to the JIRA issue**
- https://jira.talendforge.org/browse/TDQ-18518

**What is the problem this Pull Request is trying to solve?**
make sure **.datamart.jar can set version before that it is 6.0 always
 
**What is the chosen solution to this problem?**
Give a version for this kind of jar
 
**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

## Reviewer

**Please check if the Pull Request fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] (if needed) Docs have been added / updated
- [ ] Changelog has been updated
