### PR TITLE
fix(TDP-5239): Cope with the new dictionary service architecture

### DIFF
--- a/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/quality/ValueQualityAnalyzer.java
+++ b/dataquality-statistics/src/main/java/org/talend/dataquality/statistics/quality/ValueQualityAnalyzer.java
@@ -99,7 +99,11 @@ public class ValueQualityAnalyzer implements Analyzer<ValueQualityStatistics> {
     }
 
     @Override
-    public void close() {
+    public void close() throws Exception {
+        dataTypeQualityAnalyzer.close();
+        if (semanticQualityAnalyzer != null) {
+            semanticQualityAnalyzer.close();
+        }
     }
 
 }

--- a/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/quality/ValueQualityAnalyzerTest.java
+++ b/dataquality-statistics/src/test/java/org/talend/dataquality/statistics/quality/ValueQualityAnalyzerTest.java
@@ -13,7 +13,7 @@
 package org.talend.dataquality.statistics.quality;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.talend.dataquality.statistics.type.DataTypeEnum.STRING;
 
 import java.io.IOException;
@@ -177,4 +177,15 @@ public class ValueQualityAnalyzerTest {
         assertEquals(789, dataTypeStatistics.getUnknownCount());
     }
 
+    @Test
+    public void testClose() throws Exception {
+        DataTypeQualityAnalyzer dataTypeQualityAnalyzer = Mockito.mock(DataTypeQualityAnalyzer.class);
+        QualityAnalyzer analyzer = Mockito.mock(QualityAnalyzer.class);
+        ValueQualityAnalyzer valueQualityAnalyzer = new ValueQualityAnalyzer(dataTypeQualityAnalyzer, analyzer);
+
+        valueQualityAnalyzer.close();
+
+        verify(dataTypeQualityAnalyzer, times(1)).close();
+        verify(analyzer, times(1)).close();
+    }
 }


### PR DESCRIPTION
* Close inner Analyzers in ValueQualityAnalyzer close method.

## Developer

**Link to the JIRA issue**
- https://jira.talendforge.org/browse/TDP-5239

**What is the problem this Pull Request is trying to solve?**
When we close a ValueQualityAnalyzer the two inner Analyzers is not closed and some potential resource are not closed.
 
**What is the chosen solution to this problem?**
  close the inner Analyzers
 
**Does this PR introduce a breaking change?**

- [ ] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration path for existing applications: ...

## Reviewer

**Please check if the Pull Request fulfills these requirements**
- [ ] The commit(s) message(s) follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) ?
- [ ] Tests for the changes have been added (for bug fixes / features, coverage should be over 75% in the new code)
- [ ] (if needed) Docs have been added / updated
- [ ] Changelog has been updated
